### PR TITLE
F2calv/2026 03 updates3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,15 @@
 # Copilot Instructions
 
-## Code Quality Conventions
+<!-- ── Synced section ─────────────────────────────────────────────────────
+     Everything above the "Project-Specific Overrides" heading is kept
+     identical across all CasCap repositories. Edit once, sync everywhere.
+     ──────────────────────────────────────────────────────────────────── -->
+
+## C# / .NET
 
 ### Style (enforced by `.editorconfig`)
 
-- **Class-per-file**: Each class, record, struct, or enum should be in its own file, and the filename must match the type name (e.g. `MyService.cs` for `class MyService`). Nested private types used only by their enclosing class are exempt. Enums are also exempt — prefer consolidating all enums within a project into a single `_Enums.cs` file for a quick overview of available enumerations.
+- **Class-per-file**: Each class, record, struct, or enum should be in its own file, and the filename must match the type name (e.g. `MyService.cs` for `class MyService`). Nested private types used only by their enclosing class are exempt. Enums are also exempt — prefer consolidating all enums within a project into a single `_Enums.cs` file for a quick overview of available enumerations. `IAppConfig` implementations (and their child/nested configuration classes) are also exempt — their filenames are conventionally prefixed with an underscore (e.g. `_AppConfig.cs` for `record AppConfig`). The underscore does **not** appear in the type name itself; it exists solely to group configuration files at the top of the file explorer via alphabetical ordering and to make them easy to identify at a glance.
 - **Indentation**: 4 spaces, LF line endings, insert final newline
 - **Interfaces**: Must start with `I` (PascalCase) and live in an Abstractions folder and an Abstractions namespace.
 - **Types/Methods/Properties**: PascalCase
@@ -15,6 +20,7 @@
 - **Braces**: Allman style (`csharp_new_line_before_open_brace = all`). For `if`, `else`, `foreach`, `for`, `while`, and `using` statements whose body is a single statement, omit the curly braces to reduce vertical verbosity.
 - **Expression-bodied members**: Preferred for accessors, properties, indexers, lambdas; **not** for constructors, operators, or local functions. For methods, use an expression body (`=>`) when the method contains a single expression. If the combined method signature and expression would cause horizontal scrolling on smaller editor windows, place the `=>` and expression on the next line, indented.
 - **Async pass-through**: When a method is a thin wrapper that only returns another async call (no `using`, `try`/`catch`, or additional `await`s), drop `async`/`await` and return the `Task`/`ValueTask` directly to avoid unnecessary state-machine overhead.
+- **Async/Await**: Always await async method calls.
 - **Pattern matching**: Preferred (`is`, `not`, switch expressions)
 - **Primary constructors**: Preferred (`csharp_style_prefer_primary_constructors = true`)
 - **`var`**: Preferred — use `var` unless the type is not obvious from the right-hand side
@@ -24,6 +30,8 @@
 - **No magic strings**: Avoid using string literals as dictionary keys or lookup identifiers in multiple places. Instead, define a `const` field using `nameof()` so the key is a single point of change (e.g. `public const string SummaryValues = nameof(SummaryValues);`).
 - **Namespaces**: The convention is folder-based namespacing. However, the `Services` folder is exempt — sub-folders under `Services` do **not** automatically get a sub-namespace. When creating a new sub-folder under `Services`, ask the user whether the sub-folder should introduce a sub-namespace (present a yes/no choice) before proceeding.
 - **Namespace declarations**: File-scoped (not block-scoped). Using directives go above the namespace.
+- **Using directive ordering**: Pure alphabetical — do **not** place `System.*` first (`dotnet_sort_system_directives_first = false`). No blank line separators between groups (`dotnet_separate_import_directive_groups = false`). This applies to both regular `using` directives and `global using` directives in `GlobalUsings.cs`.
+- **Global usings file**: Every project must have a `GlobalUsings.cs` file located in the project root (not in a sub-folder). The file must always be named `GlobalUsings.cs`.
 - **Standard overrides at bottom**: Standard C# overrides such as `ToString`, `GetHashCode`, and `Equals` should be placed at the bottom of the class/record body, just above any `#region` blocks for private/static helpers.
 - **Property spacing**: Separate each public property declaration (`get`/`set`/`init`) with a blank line (including in records and classes with only auto-properties). Private backing fields, however, should appear on consecutive lines with **no** blank line between them.
 
@@ -33,11 +41,12 @@ Configured in `Directory.Build.props`: `IDE1006`, `IDE0079`, `IDE0042`, `CS0162`
 
 ### XML Documentation
 
-- Every public class, record, method, property, and enum member should have an XML comment.
+- Every public or internal class, record, method, property, and enum member should have an XML comment.
 - **Exception — test projects**: XML comments are required on classes, records, and properties but **not** on test methods.
 - **Document fully on the interface** — use `/// <inheritdoc/>` on implementing classes to avoid duplication.
 - When an enum is a public method parameter, use `<inheritdoc cref="EnumType" path="/summary"/>` in the `<param>` tag rather than repeating the enum's documentation.
 - **Deep link referenced types**: When XML comments reference .NET classes, structs, interfaces, enums, or namespaces, use `<see cref="Fully.Qualified.TypeName" />` instead of plain text (e.g. `<see cref="Azure.Data.Tables.TableEntity" />`).
+- **Timespan config properties**: Any configuration property on an `IAppConfig` implementation that represents a duration (conventionally suffixed with `Ms`) must include a `<see cref="…"/>` deep link to every service class that consumes it in its XML documentation. This ties the property to its consumers and makes it easy to navigate from configuration to consuming code (e.g. `/// Used by <see cref="CasCap.Services.MyMonitorBgService"/>.`).
 - **Preserve hyperlinks**: Inline comment hyperlinks to external resources (e.g. blog posts, StackOverflow answers, GitHub issues) must never be deleted. When refactoring a comment into XML documentation, move the URL into a `<remarks>` block using `<see href="…" />` (e.g. `/// <remarks>See <see href="https://example.com" />.</remarks>`).
 
 ### Logging
@@ -55,3 +64,93 @@ Configured in `Directory.Build.props`: `IDE1006`, `IDE0079`, `IDE0042`, `CS0162`
 ### Multi-Targeting
 
 - Library code using APIs unavailable in lower target frameworks must use `#if` preprocessor guards (e.g. `#if NET8_0_OR_GREATER`).
+
+## MCP (Model Context Protocol)
+
+Feature libraries with `*QueryService` types decorated with `[McpServerToolType]` follow these conventions. Individual methods exposed to the Agent are decorated with `[McpServerTool]` and every such method — including currently commented-out candidates — must also carry a `[Description]` attribute on the method and on each of its parameters. Return-type objects and their nested types must have `[Description]` on every public property.
+
+### Pattern
+
+```csharp
+[McpServerTool]
+[Description("...")]
+public async Task<Foo> DoSomething(
+    [Description("...")] string bar,
+    CancellationToken cancellationToken = default)
+```
+
+> Note: `McpServerToolAttribute` (v1.1.0) has **no** `Description` property. The correct pattern is always two separate attributes: `[McpServerTool]` then `[Description(...)]`.
+
+### MCP `[Description]` text vs XML doc comments
+
+XML doc comments (`<summary>`, `<param>`, `<returns>`) are read by developers and tooling (IntelliSense, generated docs). They may contain `<see cref="..."/>` deep-links, `<remarks>` blocks, multi-sentence explanations, and coding-specific detail.
+
+`[Description]` text on MCP tools is **not** UI copy and is **not** a contract with humans. It is:
+
+- Contextual guidance for an LLM deciding **which tool to call** and **how to map arguments**
+- Never shown to end users
+- Not subject to grammar or localisation requirements
+
+Therefore MCP descriptions should be:
+
+- **Concise** — one sentence per method/parameter is usually enough
+- **Semantically rich** — include the key noun, verb, and any units or constraints the LLM needs (e.g. `"0=fully open, 100=fully closed"`, `"range 14–25"`)
+- **Disambiguation-first** — if two tools or parameters could be confused, the description must distinguish them
+- **Enum-aware** — when a parameter is typed as `string` but represents an enum, list **all valid values with a brief label** in the description text (the LLM cannot infer them from the type):
+
+```csharp
+[Description("Floor filter. Values: Ground, Upper, Basement, Attic.")]
+string? floor = null
+```
+
+- **No XML markup** — plain text only; `<see cref="..."/>` links are meaningless to an LLM
+- **No localization** — English only; multiple languages add noise without benefit
+
+### Checklist when adding or editing a `[McpServerTool]` method
+
+1. Add `[McpServerTool]` then `[Description("...")]` on the method — one sentence naming what it does.
+2. Add `[Description("...")]` on every non-`CancellationToken` parameter.
+3. For `string` parameters representing an enum: list all enum member names with a brief description each.
+4. For complex request-object parameters: summarise the key fields and their constraints in the description.
+5. Ensure every public property on the return type (and any nested types) has `[Description("...")]` with a concise label and unit/range where applicable.
+6. Keep XML `<summary>` comments intact — they serve a different audience and must not be replaced by or merged with `[Description]` text.
+
+## Cloud (Azure)
+
+- **Azure Table Storage column naming**: For high-volume line-item/reading entities where many thousands of rows are retrieved, use ultra-short column names (even single letters) to reduce payload size and improve retrieval speed. This optimization is not needed for low-volume snapshot/summary entities where readability is more important.
+
+## GitHub Actions
+
+- **Step naming — one-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+
+## Documentation
+
+### README Consistency
+
+- **Every project must have a `README.md`**: When adding a new `.csproj` project, create a `README.md` in the project directory as part of the same commit. Follow the existing pattern: Purpose → Services/Extensions → Configuration → Dependencies (NuGet packages table + Project references table).
+- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan each affected project's `README.md` for inconsistencies: outdated service names, missing or removed configuration options, stale dependency tables, or inaccurate flow diagrams. Update the README as part of the same change, not as a follow-up.
+- **Major refactorings** (renames, project moves, DI restructuring, model type splits): when a rename or restructure touches type names, configuration sections, or project references, update every `README.md` that mentions the old names **in the same commit**. Do not leave stale references for a follow-up.
+- For large refactorings that touch multiple projects, review all impacted `README.md` files before opening the PR.
+- **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate NuGet package dependency graphs, GitHub Actions workflow chains, and .NET service/class hierarchies. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
+
+## Configuration
+
+### Configuration Sync
+
+- Configuration properties (e.g. polling delays, feature flags, thresholds) are defined with sensible defaults directly on the `IAppConfig` record/class. Having defaults in the record means the application works out-of-the-box, but every property can be overridden via `appsettings*.json` or directly with environment variables in Kubernetes deployments (using the standard `CasCap__SectionName__PropertyName` double-underscore convention).
+- When adding, renaming, or removing a property on any class or record that implements `IAppConfig` — or on any child/nested type reachable from such a class — update **all** `appsettings*.json` files (`appsettings.json`, `appsettings.Development.json`, and any other environment-specific variants) in the same commit. This includes adding new keys with sensible defaults, renaming keys to match the new property name, and removing keys for deleted properties. If the new property's record default is already the desired value for all environments, the `appsettings*.json` files do not need a new entry — only add one when an environment-specific override is required.
+
+## Copilot Workflow
+
+- **Test execution after refactoring**: After completing a refactoring, always prompt the user with a yes/no choice before running any tests. Do not automatically run tests. When prompting, offer a clickable yes/no UI option if the environment supports it.
+- **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
+
+## Misc
+
+- When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.
+
+---
+
+## Project-Specific Overrides
+
+<!-- This section is excluded from cross-repository sync. Place any repo-specific rules below. -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -182,6 +182,7 @@ string? floor = null
 - **Major refactorings** (renames, project moves, DI restructuring, model type splits): when a rename or restructure touches type names, configuration sections, or project references, update every `README.md` that mentions the old names **in the same commit**. Do not leave stale references for a follow-up.
 - For large refactorings that touch multiple projects, review all impacted `README.md` files before opening the PR.
 - **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate NuGet package dependency graphs, GitHub Actions workflow chains, and .NET service/class hierarchies. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
+- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
 
 ## Configuration
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,7 +121,57 @@ string? floor = null
 
 ## GitHub Actions
 
-- **Step naming — one-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+### General
+
+- Always leave **one blank line between steps** within a job for readability.
+- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
+- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
+- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+
+### Step Naming
+
+- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
+- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
+
+### Naming Conventions
+
+- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
+- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
+- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
+
+### YAML Style
+
+- **2-space indentation** for all workflow and action YAML files.
+- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
+- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
+- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
+- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
+
+### Reusable Workflows
+
+- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **Same repo**: `uses: ./.github/workflows/_filename.yml`
+- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
+- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
+
+### Composite Actions
+
+- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
+- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+
+### Security
+
+- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
+- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
+- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
+- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
+
+### GitVersion
+
+- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
+- Default config file is `GitVersion.yml` in the repository root.
+- Prefer `semVer` for tags and releases; use `fullSemVer` for display and pre-release identifiers.
 
 ## Documentation
 

--- a/.github/prompts/summarize-for-pr.prompt.md
+++ b/.github/prompts/summarize-for-pr.prompt.md
@@ -1,0 +1,62 @@
+---
+description: "Create a temporary markdown file summarising all branch changes vs. main/master for PR review"
+agent: "agent"
+---
+
+# Summarize Branch Changes for PR
+
+Create a temporary markdown file in the repository root called `BRANCH_CHANGES.md` that summarises all changes on the current branch compared to the master/main/default branch. This file is intended to aid PR review and should be deleted before merging.
+
+## Input
+
+No explicit input required — the summary is derived from git history and the current Copilot session context.
+
+## Steps
+
+### 1. Gather Git Context
+
+- Determine the current branch name (`git branch --show-current`).
+- Find the merge base with `origin/master`.
+- Collect the commit log between the merge base and HEAD (`git log --oneline`).
+- Collect the diff stat (`git diff --stat`), file change list (`--diff-filter`), and numstat.
+
+### 2. Distil Session Requests (if applicable)
+
+If Copilot session context is available, extract the key user requests that drove the changes and present them as a bullet-point list at the top of the file under a **Copilot Session Requests** heading.
+
+### 3. Produce the Markdown File
+
+Create `BRANCH_CHANGES.md` in the repository root with the following sections:
+
+#### Header
+
+- Branch name, base branch, and current date.
+
+#### Copilot Session Requests
+
+- Bullet list of the user prompts/requests from the current session that led to changes (omit if no session context).
+
+#### Commits
+
+- Table with columns: Hash, Message, Author, Date.
+
+#### Files Changed
+
+- Table with columns: File, Change type (Added/Modified/Deleted), Insertions, Deletions.
+- Summary line: _N files changed, X insertions, Y deletions._
+
+#### Change Details
+
+- One sub-heading per changed file (or logical group of related files).
+- Numbered list of the distinct changes made, written for a reviewer who is unfamiliar with the recent context.
+
+#### Pending Session Work (if applicable)
+
+- Any in-progress or uncommitted work from the current Copilot session that has not yet been committed.
+
+## Guidelines
+
+- Keep descriptions concise but specific — a reviewer should understand _what_ changed and _why_ without reading the diff.
+- Use git data as the source of truth; supplement with session context only for intent and motivation.
+- Do not include the full diff content — summarise it.
+- Mark the file clearly as temporary (mention it should be deleted before merge).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,15 @@ jobs:
       move-major-tag: false
 
   # SonarQube:
-  #   runs-on: windows-latest
+  #   runs-on: ubuntu-latest
   #   needs: build
   #   steps:
-  #     - uses: f2calv/gha-sonarqube-dotnet@v1
+  #     - uses: actions/checkout@v6
   #       with:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  #         configuration: ${{ needs.build.outputs.configuration }}
+  #         fetch-depth: 0
+  #
+  #     - uses: f2calv/gha-sonarqube-dotnet@v2
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         sonar-token: ${{ secrets.SONAR_TOKEN }}
+  #         build-configuration: ${{ inputs.configuration }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Core" Version="1.51.1" />
+    <PackageVersion Include="Azure.Core" Version="1.52.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.19.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
     <PackageVersion Include="Azure.Core" Version="1.52.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.19.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
@@ -14,18 +14,18 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.7.1" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.7.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.7.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.7.1" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.7.1" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.8.0" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.8.0" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.8.0" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.8.0" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.48.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="coverlet.msbuild" Version="8.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="8.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,15 +1,15 @@
-mode: MainLine
+mode: ContinuousDeployment
 branches:
   main:
     regex: ^main$
-    tag: ''
+    label: ''
   feature:
     regex: ^features?[/-]
-    tag: useBranchName
+    label: useBranchName
   preview:
     regex: ^preview?[/-]
-    tag: preview-{BranchName}
-    source-branches: ['main']
+    label: preview-{BranchName}
+    source-branches: [main]
 ignore:
   sha: []
 merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,120 @@ A collection of .NET helper class libraries for interacting with Azure PaaS serv
 
 **Dependency:** Debug builds require [CasCap.Common](https://github.com/f2calv/CasCap.Common) cloned at the same directory level.
 
+## Projects
+
+| Project | Description | README |
+|---------|-------------|--------|
+| **CasCap.Api.Azure.AppInsights** | Application Insights configuration & DI registration | [README](src/CasCap.Api.Azure.AppInsights/README.md) |
+| **CasCap.Api.Azure.CognitiveServices** | Speech-to-text and text-to-speech via Azure Speech SDK | [README](src/CasCap.Api.Azure.CognitiveServices/README.md) |
+| **CasCap.Api.Azure.ContainerRegistry** | Azure Container Registry repository/manifest listing | [README](src/CasCap.Api.Azure.ContainerRegistry/README.md) |
+| **CasCap.Api.Azure.EventGrid** | Azure Event Grid messaging (placeholder) | [README](src/CasCap.Api.Azure.EventGrid/README.md) |
+| **CasCap.Api.Azure.EventHub** | Event Hub publisher/subscriber with MessagePack serialization | [README](src/CasCap.Api.Azure.EventHub/README.md) |
+| **CasCap.Api.Azure.LogAnalytics** | Log Analytics query service for Application Insights | [README](src/CasCap.Api.Azure.LogAnalytics/README.md) |
+| **CasCap.Api.Azure.ServiceBus** | Service Bus queue and topic send/receive operations | [README](src/CasCap.Api.Azure.ServiceBus/README.md) |
+| **CasCap.Api.Azure.Storage** | Blob, Queue, and Table storage base services | [README](src/CasCap.Api.Azure.Storage/README.md) |
+| **CasCap.Api.Azure.Storage.Tests** | xUnit integration tests for Storage (requires Azurite) | [README](src/CasCap.Api.Azure.Storage.Tests/README.md) |
+
+## Dependency Graph
+
+### NuGet Package Dependencies
+
+```mermaid
+graph TD
+    subgraph "CasCap.Common (external)"
+        Logging["CasCap.Common.Logging"]
+        Ext["CasCap.Common.Extensions"]
+        SerJson["CasCap.Common.Serialization.Json"]
+        SerMsgPack["CasCap.Common.Serialization.MessagePack"]
+        Testing["CasCap.Common.Testing"]
+    end
+
+    subgraph "CasCap.Api.Azure Libraries"
+        AI["AppInsights"]
+        CS["CognitiveServices"]
+        CR["ContainerRegistry"]
+        EG["EventGrid"]
+        EH["EventHub"]
+        LA["LogAnalytics"]
+        SB["ServiceBus"]
+        ST["Storage"]
+    end
+
+    Tests["Storage.Tests"]
+
+    AI --> Logging
+    AI --> Ext
+
+    CS --> Logging
+    CS --> Ext
+
+    CR --> Logging
+    CR --> Ext
+
+    EG --> Logging
+    EG --> Ext
+
+    EH --> Logging
+    EH --> Ext
+    EH --> SerMsgPack
+
+    LA --> Logging
+    LA --> Ext
+
+    SB --> Logging
+    SB --> Ext
+
+    ST --> Logging
+    ST --> Ext
+    ST --> SerJson
+
+    Tests --> ST
+    Tests --> Logging
+    Tests --> Testing
+```
+
+### Azure SDK Dependencies
+
+```mermaid
+graph LR
+    subgraph "Azure SDKs"
+        AzCore["Azure.Core"]
+        AzIdentity["Azure.Identity"]
+        AzBlobs["Azure.Storage.Blobs"]
+        AzQueues["Azure.Storage.Queues"]
+        AzTables["Azure.Data.Tables"]
+        AzEG["Azure.Messaging.EventGrid"]
+        AzEH["Azure.Messaging.EventHubs"]
+        AzEHP["Azure.Messaging.EventHubs.Processor"]
+        AzSB["Azure.Messaging.ServiceBus"]
+        AzMQ["Azure.Monitor.Query"]
+        AzACR["Azure.Containers.ContainerRegistry"]
+        CogSpeech["Microsoft.CognitiveServices.Speech"]
+    end
+
+    AI["AppInsights"]
+    CS["CognitiveServices"] --> CogSpeech
+    CR["ContainerRegistry"] --> AzACR
+    CR --> AzIdentity
+    EG["EventGrid"] --> AzEG
+    EH["EventHub"] --> AzEH
+    EH --> AzEHP
+    LA["LogAnalytics"] --> AzIdentity
+    LA --> AzMQ
+    SB["ServiceBus"] --> AzSB
+    ST["Storage"] --> AzCore
+    ST --> AzBlobs
+    ST --> AzQueues
+    ST --> AzTables
+```
+
+### Project Reference Graph
+
+```mermaid
+graph TD
+    Tests["Storage.Tests"] --> ST["Storage"]
+```
+
 ## Project Structure
 
 ```text

--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # CasCap.Api.Azure
 
+[cascap.api.azure.appinsights-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.AppInsights?color=blue
+[cascap.api.azure.appinsights-url]: https://nuget.org/packages/CasCap.Api.Azure.AppInsights
+[cascap.api.azure.cognitiveservices-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.CognitiveServices?color=blue
+[cascap.api.azure.cognitiveservices-url]: https://nuget.org/packages/CasCap.Api.Azure.CognitiveServices
+[cascap.api.azure.containerregistry-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.ContainerRegistry?color=blue
+[cascap.api.azure.containerregistry-url]: https://nuget.org/packages/CasCap.Api.Azure.ContainerRegistry
+[cascap.api.azure.eventgrid-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.EventGrid?color=blue
+[cascap.api.azure.eventgrid-url]: https://nuget.org/packages/CasCap.Api.Azure.EventGrid
+[cascap.api.azure.eventhub-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.EventHub?color=blue
+[cascap.api.azure.eventhub-url]: https://nuget.org/packages/CasCap.Api.Azure.EventHub
+[cascap.api.azure.loganalytics-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.LogAnalytics?color=blue
+[cascap.api.azure.loganalytics-url]: https://nuget.org/packages/CasCap.Api.Azure.LogAnalytics
+[cascap.api.azure.servicebus-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.ServiceBus?color=blue
+[cascap.api.azure.servicebus-url]: https://nuget.org/packages/CasCap.Api.Azure.ServiceBus
+[cascap.api.azure.storage-badge]: https://img.shields.io/nuget/v/CasCap.Api.Azure.Storage?color=blue
+[cascap.api.azure.storage-url]: https://nuget.org/packages/CasCap.Api.Azure.Storage
+
 A collection of .NET helper class libraries for interacting with Azure PaaS services. The repository contains 9 projects (8 libraries + 1 test project) targeting net8.0, net9.0, and net10.0.
+
+| Library | Package |
+| --- | --- |
+| CasCap.Api.Azure.AppInsights | [![Nuget][cascap.api.azure.appinsights-badge]][cascap.api.azure.appinsights-url] |
+| CasCap.Api.Azure.CognitiveServices | [![Nuget][cascap.api.azure.cognitiveservices-badge]][cascap.api.azure.cognitiveservices-url] |
+| CasCap.Api.Azure.ContainerRegistry | [![Nuget][cascap.api.azure.containerregistry-badge]][cascap.api.azure.containerregistry-url] |
+| CasCap.Api.Azure.EventGrid | [![Nuget][cascap.api.azure.eventgrid-badge]][cascap.api.azure.eventgrid-url] |
+| CasCap.Api.Azure.EventHub | [![Nuget][cascap.api.azure.eventhub-badge]][cascap.api.azure.eventhub-url] |
+| CasCap.Api.Azure.LogAnalytics | [![Nuget][cascap.api.azure.loganalytics-badge]][cascap.api.azure.loganalytics-url] |
+| CasCap.Api.Azure.ServiceBus | [![Nuget][cascap.api.azure.servicebus-badge]][cascap.api.azure.servicebus-url] |
+| CasCap.Api.Azure.Storage | [![Nuget][cascap.api.azure.storage-badge]][cascap.api.azure.storage-url] |
 
 **Solution Files:**
 
@@ -12,7 +40,7 @@ A collection of .NET helper class libraries for interacting with Azure PaaS serv
 ## Projects
 
 | Project | Description | README |
-| ------- | ----------- | ------ |
+| --- | --- | --- |
 | **CasCap.Api.Azure.AppInsights** | Application Insights configuration & DI registration | [README](src/CasCap.Api.Azure.AppInsights/README.md) |
 | **CasCap.Api.Azure.CognitiveServices** | Speech-to-text and text-to-speech via Azure Speech SDK | [README](src/CasCap.Api.Azure.CognitiveServices/README.md) |
 | **CasCap.Api.Azure.ContainerRegistry** | Azure Container Registry repository/manifest listing | [README](src/CasCap.Api.Azure.ContainerRegistry/README.md) |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of .NET helper class libraries for interacting with Azure PaaS serv
 ## Projects
 
 | Project | Description | README |
-|---------|-------------|--------|
+| ------- | ----------- | ------ |
 | **CasCap.Api.Azure.AppInsights** | Application Insights configuration & DI registration | [README](src/CasCap.Api.Azure.AppInsights/README.md) |
 | **CasCap.Api.Azure.CognitiveServices** | Speech-to-text and text-to-speech via Azure Speech SDK | [README](src/CasCap.Api.Azure.CognitiveServices/README.md) |
 | **CasCap.Api.Azure.ContainerRegistry** | Azure Container Registry repository/manifest listing | [README](src/CasCap.Api.Azure.ContainerRegistry/README.md) |

--- a/src/CasCap.Api.Azure.AppInsights/CasCap.Api.Azure.AppInsights.csproj
+++ b/src/CasCap.Api.Azure.AppInsights/CasCap.Api.Azure.AppInsights.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Application Insights.</Description>
-    <PackageTags>azure,application,insights</PackageTags>
+    <Description>Helper library for Azure Application Insights configuration binding and dependency injection registration.</Description>
+    <PackageTags>azure,application-insights,app-insights,telemetry,configuration</PackageTags>
   </PropertyGroup>
 
   <Choose>

--- a/src/CasCap.Api.Azure.AppInsights/README.md
+++ b/src/CasCap.Api.Azure.AppInsights/README.md
@@ -1,0 +1,28 @@
+# CasCap.Api.Azure.AppInsights
+
+Helper library for Azure Application Insights. Provides configuration binding and DI registration for Application Insights instrumentation.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Extension | `AddCasCapAppInsightsServices` | Registers `AppInsightsConfig` options from the `CasCap:AppInsightsConfig` configuration section. |
+
+## Configuration
+
+| Class | Section | Properties |
+|-------|---------|------------|
+| `AppInsightsConfig` | `CasCap:AppInsightsConfig` | `InstrumentationKey` (required) |
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.AppInsights/README.md
+++ b/src/CasCap.Api.Azure.AppInsights/README.md
@@ -5,13 +5,13 @@ Helper library for Azure Application Insights. Provides configuration binding an
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Extension | `AddCasCapAppInsightsServices` | Registers `AppInsightsConfig` options from the `CasCap:AppInsightsConfig` configuration section. |
 
 ## Configuration
 
 | Class | Section | Properties |
-|-------|---------|------------|
+| ----- | ------- | ---------- |
 | `AppInsightsConfig` | `CasCap:AppInsightsConfig` | `InstrumentationKey` (required) |
 
 ## Dependencies
@@ -19,7 +19,7 @@ Helper library for Azure Application Insights. Provides configuration binding an
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `CasCap.Common.Logging` | Shared logging infrastructure |
 | `CasCap.Common.Extensions` | Common extension methods |
 

--- a/src/CasCap.Api.Azure.AppInsights/README.md
+++ b/src/CasCap.Api.Azure.AppInsights/README.md
@@ -5,23 +5,23 @@ Helper library for Azure Application Insights. Provides configuration binding an
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Extension | `AddCasCapAppInsightsServices` | Registers `AppInsightsConfig` options from the `CasCap:AppInsightsConfig` configuration section. |
 
 ## Configuration
 
 | Class | Section | Properties |
-| ----- | ------- | ---------- |
+| --- | --- | --- |
 | `AppInsightsConfig` | `CasCap:AppInsightsConfig` | `InstrumentationKey` (required) |
 
 ## Dependencies
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
+| Package |
+| --- |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.CognitiveServices/CasCap.Api.Azure.CognitiveServices.csproj
+++ b/src/CasCap.Api.Azure.CognitiveServices/CasCap.Api.Azure.CognitiveServices.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Cognitive Services.</Description>
-    <PackageTags>azure,cognitive,services</PackageTags>
+    <Description>Helper library for Azure Cognitive Services speech synthesis (TTS) and speech recognition (STT).</Description>
+    <PackageTags>azure,cognitive-services,speech,text-to-speech,speech-to-text</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.CognitiveServices/README.md
+++ b/src/CasCap.Api.Azure.CognitiveServices/README.md
@@ -1,0 +1,36 @@
+# CasCap.Api.Azure.CognitiveServices
+
+Helper library for Azure Cognitive Services. Provides text-to-speech synthesis and speech-to-text recognition via the Azure Speech SDK.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Interface | `ISpeechService` | Abstraction for speech synthesis (TTS) and speech recognition (STT). |
+| Service | `SpeechService` | Implements `ISpeechService` using `Microsoft.CognitiveServices.Speech`. Supports subscription key and `TokenCredential` authentication. |
+
+### Key Methods
+
+- `CreateWAV(string soundByte, string path)` — Synthesizes text to a WAV file.
+- `RecognizeFromWAV(string path)` — Transcribes speech from a WAV file.
+- `RecognizeFromMicrophone()` — Transcribes speech from the default microphone.
+
+## Configuration
+
+| Class | Section | Properties |
+|-------|---------|------------|
+| `CognitiveServicesConfig` | `CasCap:CognitiveServicesConfig` | `SubscriptionKey` (required) |
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Microsoft.CognitiveServices.Speech` | Azure Cognitive Services Speech SDK |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.CognitiveServices/README.md
+++ b/src/CasCap.Api.Azure.CognitiveServices/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Cognitive Services. Provides text-to-speech synthesis a
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Interface | `ISpeechService` | Abstraction for speech synthesis (TTS) and speech recognition (STT). |
 | Service | `SpeechService` | Implements `ISpeechService` using `Microsoft.CognitiveServices.Speech`. Supports subscription key and `TokenCredential` authentication. |
 
@@ -18,7 +18,7 @@ Helper library for Azure Cognitive Services. Provides text-to-speech synthesis a
 ## Configuration
 
 | Class | Section | Properties |
-|-------|---------|------------|
+| ----- | ------- | ---------- |
 | `CognitiveServicesConfig` | `CasCap:CognitiveServicesConfig` | `SubscriptionKey` (required) |
 
 ## Dependencies
@@ -26,7 +26,7 @@ Helper library for Azure Cognitive Services. Provides text-to-speech synthesis a
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Microsoft.CognitiveServices.Speech` | Azure Cognitive Services Speech SDK |
 | `CasCap.Common.Logging` | Shared logging infrastructure |
 | `CasCap.Common.Extensions` | Common extension methods |

--- a/src/CasCap.Api.Azure.CognitiveServices/README.md
+++ b/src/CasCap.Api.Azure.CognitiveServices/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Cognitive Services. Provides text-to-speech synthesis a
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Interface | `ISpeechService` | Abstraction for speech synthesis (TTS) and speech recognition (STT). |
 | Service | `SpeechService` | Implements `ISpeechService` using `Microsoft.CognitiveServices.Speech`. Supports subscription key and `TokenCredential` authentication. |
 
@@ -18,18 +18,18 @@ Helper library for Azure Cognitive Services. Provides text-to-speech synthesis a
 ## Configuration
 
 | Class | Section | Properties |
-| ----- | ------- | ---------- |
+| --- | --- | --- |
 | `CognitiveServicesConfig` | `CasCap:CognitiveServicesConfig` | `SubscriptionKey` (required) |
 
 ## Dependencies
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Microsoft.CognitiveServices.Speech` | Azure Cognitive Services Speech SDK |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
+| Package |
+| --- |
+| [Microsoft.CognitiveServices.Speech](https://www.nuget.org/packages/microsoft.cognitiveservices.speech) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.ContainerRegistry/CasCap.Api.Azure.ContainerRegistry.csproj
+++ b/src/CasCap.Api.Azure.ContainerRegistry/CasCap.Api.Azure.ContainerRegistry.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Container Registry.</Description>
-    <PackageTags>azure,container,registry</PackageTags>
+    <Description>Helper library for Azure Container Registry repository and manifest operations.</Description>
+    <PackageTags>azure,container-registry,acr,docker,containers</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.ContainerRegistry/README.md
+++ b/src/CasCap.Api.Azure.ContainerRegistry/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Container Registry. Provides a base service class for l
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Service | `AcrServiceBase` | Abstract base class for ACR operations. Authenticates via `TokenCredential` and provides repository/manifest listing. |
 
 ### Key Methods
@@ -21,7 +21,7 @@ No configuration model. The service is constructed directly with a `Uri` endpoin
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Azure.Containers.ContainerRegistry` | Azure Container Registry client library |
 | `Azure.Identity` | Azure identity and credential providers |
 | `CasCap.Common.Logging` | Shared logging infrastructure |

--- a/src/CasCap.Api.Azure.ContainerRegistry/README.md
+++ b/src/CasCap.Api.Azure.ContainerRegistry/README.md
@@ -1,0 +1,32 @@
+# CasCap.Api.Azure.ContainerRegistry
+
+Helper library for Azure Container Registry. Provides a base service class for listing repositories and manifests.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Service | `AcrServiceBase` | Abstract base class for ACR operations. Authenticates via `TokenCredential` and provides repository/manifest listing. |
+
+### Key Methods
+
+- `ListRepos()` — Lists all repositories and their manifests in the registry.
+
+## Configuration
+
+No configuration model. The service is constructed directly with a `Uri` endpoint and `TokenCredential`.
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Azure.Containers.ContainerRegistry` | Azure Container Registry client library |
+| `Azure.Identity` | Azure identity and credential providers |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.ContainerRegistry/README.md
+++ b/src/CasCap.Api.Azure.ContainerRegistry/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Container Registry. Provides a base service class for l
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Service | `AcrServiceBase` | Abstract base class for ACR operations. Authenticates via `TokenCredential` and provides repository/manifest listing. |
 
 ### Key Methods
@@ -20,12 +20,12 @@ No configuration model. The service is constructed directly with a `Uri` endpoin
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Azure.Containers.ContainerRegistry` | Azure Container Registry client library |
-| `Azure.Identity` | Azure identity and credential providers |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
+| Package |
+| --- |
+| [Azure.Containers.ContainerRegistry](https://www.nuget.org/packages/azure.containers.containerregistry) |
+| [Azure.Identity](https://www.nuget.org/packages/azure.identity) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.EventGrid/CasCap.Api.Azure.EventGrid.csproj
+++ b/src/CasCap.Api.Azure.EventGrid/CasCap.Api.Azure.EventGrid.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure EventGrid.</Description>
-    <PackageTags>azure,eventgrid</PackageTags>
+    <Description>Helper library for Azure Event Grid messaging.</Description>
+    <PackageTags>azure,event-grid,eventgrid,messaging,events</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.EventGrid/README.md
+++ b/src/CasCap.Api.Azure.EventGrid/README.md
@@ -16,11 +16,11 @@ None.
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Azure.Messaging.EventGrid` | Azure Event Grid client library |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
+| Package |
+| --- |
+| [Azure.Messaging.EventGrid](https://www.nuget.org/packages/azure.messaging.eventgrid) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.EventGrid/README.md
+++ b/src/CasCap.Api.Azure.EventGrid/README.md
@@ -1,0 +1,27 @@
+# CasCap.Api.Azure.EventGrid
+
+Helper library for Azure Event Grid. Provides foundational package references for Event Grid messaging integration.
+
+> **Note:** This project currently contains no service classes or interfaces. It serves as a packaging placeholder with the `Azure.Messaging.EventGrid` SDK dependency ready for consumption by downstream projects.
+
+## Services / Extensions
+
+None.
+
+## Configuration
+
+None.
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Azure.Messaging.EventGrid` | Azure Event Grid client library |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.EventGrid/README.md
+++ b/src/CasCap.Api.Azure.EventGrid/README.md
@@ -17,7 +17,7 @@ None.
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Azure.Messaging.EventGrid` | Azure Event Grid client library |
 | `CasCap.Common.Logging` | Shared logging infrastructure |
 | `CasCap.Common.Extensions` | Common extension methods |

--- a/src/CasCap.Api.Azure.EventHub/CasCap.Api.Azure.EventHub.csproj
+++ b/src/CasCap.Api.Azure.EventHub/CasCap.Api.Azure.EventHub.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Event Hub.</Description>
-    <PackageTags>azure,event,hub</PackageTags>
+    <Description>Helper library for Azure Event Hub publish/subscribe streaming with MessagePack serialization.</Description>
+    <PackageTags>azure,event-hub,eventhub,streaming,messaging</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.EventHub/README.md
+++ b/src/CasCap.Api.Azure.EventHub/README.md
@@ -1,0 +1,44 @@
+# CasCap.Api.Azure.EventHub
+
+Helper library for Azure Event Hub. Provides generic publisher and subscriber base services for streaming events via Event Hubs, with MessagePack serialization.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Interface | `IEvent` | Marker interface for Event Hub event objects. |
+| Interface | `IPublisherService<T>` | Abstraction for publishing messages to an Event Hub. |
+| Interface | `ISubscriberService<T>` | Abstraction for receiving and processing messages from an Event Hub. |
+| Service | `PublisherService<T>` | Abstract base implementing `IPublisherService<T>`. Serializes events via MessagePack and sends them in batches. Supports connection string and `TokenCredential` authentication. |
+| Service | `SubscriberService<T>` | Abstract base implementing `ISubscriberService<T>`. Uses `EventProcessorClient` with blob checkpoint storage for reliable event processing. Supports connection string and `TokenCredential` authentication. |
+
+### Key Methods — `PublisherService<T>`
+
+- `Push(T obj)` — Serializes and pushes a single event.
+- `Push(List<T> objs)` — Serializes and pushes a list of events.
+- `Push(byte[] bytes)` — Pushes a raw byte array as a single event.
+- `SendTestMessages(int numMessagesToSend)` — Sends test messages to the Event Hub.
+
+### Key Methods — `SubscriberService<T>`
+
+- `InitiateReceive(CancellationToken)` — Begins processing events until cancellation.
+
+## Configuration
+
+No configuration model. Services are constructed directly with connection strings or `TokenCredential`.
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Azure.Messaging.EventHubs` | Azure Event Hubs client library |
+| `Azure.Messaging.EventHubs.Processor` | Event Hubs processor with checkpoint support |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+| `CasCap.Common.Serialization.MessagePack` | MessagePack serialization helpers |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.EventHub/README.md
+++ b/src/CasCap.Api.Azure.EventHub/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Event Hub. Provides generic publisher and subscriber ba
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Interface | `IEvent` | Marker interface for Event Hub event objects. |
 | Interface | `IPublisherService<T>` | Abstraction for publishing messages to an Event Hub. |
 | Interface | `ISubscriberService<T>` | Abstraction for receiving and processing messages from an Event Hub. |
@@ -31,13 +31,13 @@ No configuration model. Services are constructed directly with connection string
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Azure.Messaging.EventHubs` | Azure Event Hubs client library |
-| `Azure.Messaging.EventHubs.Processor` | Event Hubs processor with checkpoint support |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
-| `CasCap.Common.Serialization.MessagePack` | MessagePack serialization helpers |
+| Package |
+| --- |
+| [Azure.Messaging.EventHubs](https://www.nuget.org/packages/azure.messaging.eventhubs) |
+| [Azure.Messaging.EventHubs.Processor](https://www.nuget.org/packages/azure.messaging.eventhubs.processor) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
+| [CasCap.Common.Serialization.MessagePack](https://www.nuget.org/packages/cascap.common.serialization.messagepack) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.EventHub/README.md
+++ b/src/CasCap.Api.Azure.EventHub/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Event Hub. Provides generic publisher and subscriber ba
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Interface | `IEvent` | Marker interface for Event Hub event objects. |
 | Interface | `IPublisherService<T>` | Abstraction for publishing messages to an Event Hub. |
 | Interface | `ISubscriberService<T>` | Abstraction for receiving and processing messages from an Event Hub. |
@@ -32,7 +32,7 @@ No configuration model. Services are constructed directly with connection string
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Azure.Messaging.EventHubs` | Azure Event Hubs client library |
 | `Azure.Messaging.EventHubs.Processor` | Event Hubs processor with checkpoint support |
 | `CasCap.Common.Logging` | Shared logging infrastructure |

--- a/src/CasCap.Api.Azure.LogAnalytics/CasCap.Api.Azure.LogAnalytics.csproj
+++ b/src/CasCap.Api.Azure.LogAnalytics/CasCap.Api.Azure.LogAnalytics.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Log Analytics.</Description>
-    <PackageTags>azure,log,analytics</PackageTags>
+    <Description>Helper library for Azure Monitor Log Analytics workspace queries and Application Insights exception retrieval.</Description>
+    <PackageTags>azure,log-analytics,azure-monitor,application-insights,query</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.LogAnalytics/README.md
+++ b/src/CasCap.Api.Azure.LogAnalytics/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Log Analytics. Provides a query service for retrieving 
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Interface | `IQueryService` | Abstraction for querying Azure Monitor / Application Insights via Log Analytics. |
 | Service | `QueryService` | Implements `IQueryService` using `LogsQueryClient`. Authenticates via `TokenCredential`. |
 | Extension | `AddCasCapLogAnalyticsServices` | Registers `LogAnalyticsConfig` options and `IQueryService` / `QueryService` with the DI container. |
@@ -19,19 +19,19 @@ Helper library for Azure Log Analytics. Provides a query service for retrieving 
 ## Configuration
 
 | Class | Section | Properties |
-| ----- | ------- | ---------- |
+| --- | --- | --- |
 | `LogAnalyticsConfig` | `CasCap:LogAnalyticsConfig` | `WorkspaceId` (required) |
 
 ## Dependencies
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Azure.Identity` | Azure identity and credential providers |
-| `Azure.Monitor.Query` | Azure Monitor Log Analytics query client |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
+| Package |
+| --- |
+| [Azure.Identity](https://www.nuget.org/packages/azure.identity) |
+| [Azure.Monitor.Query](https://www.nuget.org/packages/azure.monitor.query) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.LogAnalytics/README.md
+++ b/src/CasCap.Api.Azure.LogAnalytics/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Log Analytics. Provides a query service for retrieving 
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Interface | `IQueryService` | Abstraction for querying Azure Monitor / Application Insights via Log Analytics. |
 | Service | `QueryService` | Implements `IQueryService` using `LogsQueryClient`. Authenticates via `TokenCredential`. |
 | Extension | `AddCasCapLogAnalyticsServices` | Registers `LogAnalyticsConfig` options and `IQueryService` / `QueryService` with the DI container. |
@@ -19,7 +19,7 @@ Helper library for Azure Log Analytics. Provides a query service for retrieving 
 ## Configuration
 
 | Class | Section | Properties |
-|-------|---------|------------|
+| ----- | ------- | ---------- |
 | `LogAnalyticsConfig` | `CasCap:LogAnalyticsConfig` | `WorkspaceId` (required) |
 
 ## Dependencies
@@ -27,7 +27,7 @@ Helper library for Azure Log Analytics. Provides a query service for retrieving 
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Azure.Identity` | Azure identity and credential providers |
 | `Azure.Monitor.Query` | Azure Monitor Log Analytics query client |
 | `CasCap.Common.Logging` | Shared logging infrastructure |

--- a/src/CasCap.Api.Azure.LogAnalytics/README.md
+++ b/src/CasCap.Api.Azure.LogAnalytics/README.md
@@ -1,0 +1,38 @@
+# CasCap.Api.Azure.LogAnalytics
+
+Helper library for Azure Log Analytics. Provides a query service for retrieving Application Insights exception data via Azure Monitor Log Analytics, with DI registration and configuration binding.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Interface | `IQueryService` | Abstraction for querying Azure Monitor / Application Insights via Log Analytics. |
+| Service | `QueryService` | Implements `IQueryService` using `LogsQueryClient`. Authenticates via `TokenCredential`. |
+| Extension | `AddCasCapLogAnalyticsServices` | Registers `LogAnalyticsConfig` options and `IQueryService` / `QueryService` with the DI container. |
+| Model | `AppInsightsObject` | Record representing a single exception from an Application Insights Log Analytics query. |
+
+### Key Methods
+
+- `GetExceptions(int limit)` — Returns up to `limit` recent exception records from the workspace.
+- `Query(QueryTimeRange timeRange)` — Queries the workspace for up to 50 results and outputs to console.
+
+## Configuration
+
+| Class | Section | Properties |
+|-------|---------|------------|
+| `LogAnalyticsConfig` | `CasCap:LogAnalyticsConfig` | `WorkspaceId` (required) |
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Azure.Identity` | Azure identity and credential providers |
+| `Azure.Monitor.Query` | Azure Monitor Log Analytics query client |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.ServiceBus/CasCap.Api.Azure.ServiceBus.csproj
+++ b/src/CasCap.Api.Azure.ServiceBus/CasCap.Api.Azure.ServiceBus.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Service Bus.</Description>
-    <PackageTags>azure,service,bus</PackageTags>
+    <Description>Helper library for Azure Service Bus queue and topic send/receive operations.</Description>
+    <PackageTags>azure,service-bus,servicebus,messaging,queues,topics</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.ServiceBus/README.md
+++ b/src/CasCap.Api.Azure.ServiceBus/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Service Bus. Provides base service classes for queue an
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Interface | `IQueueService` | Abstraction for Service Bus queue send and receive operations. |
 | Interface | `ITopicService` | Abstraction for Service Bus topic send and receive operations. |
 | Service | `ServiceBase` | Abstract base class providing common message and error event handling (`MessageReceivedEvent`, `ErrorReceivedEvent`). |
@@ -33,7 +33,7 @@ No configuration model. Services are constructed directly with connection string
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Azure.Messaging.ServiceBus` | Azure Service Bus client library |
 | `CasCap.Common.Logging` | Shared logging infrastructure |
 | `CasCap.Common.Extensions` | Common extension methods |

--- a/src/CasCap.Api.Azure.ServiceBus/README.md
+++ b/src/CasCap.Api.Azure.ServiceBus/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Service Bus. Provides base service classes for queue an
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Interface | `IQueueService` | Abstraction for Service Bus queue send and receive operations. |
 | Interface | `ITopicService` | Abstraction for Service Bus topic send and receive operations. |
 | Service | `ServiceBase` | Abstract base class providing common message and error event handling (`MessageReceivedEvent`, `ErrorReceivedEvent`). |
@@ -32,11 +32,11 @@ No configuration model. Services are constructed directly with connection string
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Azure.Messaging.ServiceBus` | Azure Service Bus client library |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
+| Package |
+| --- |
+| [Azure.Messaging.ServiceBus](https://www.nuget.org/packages/azure.messaging.servicebus) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.ServiceBus/README.md
+++ b/src/CasCap.Api.Azure.ServiceBus/README.md
@@ -1,0 +1,43 @@
+# CasCap.Api.Azure.ServiceBus
+
+Helper library for Azure Service Bus. Provides base service classes for queue and topic send/receive operations with event-driven message handling.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Interface | `IQueueService` | Abstraction for Service Bus queue send and receive operations. |
+| Interface | `ITopicService` | Abstraction for Service Bus topic send and receive operations. |
+| Service | `ServiceBase` | Abstract base class providing common message and error event handling (`MessageReceivedEvent`, `ErrorReceivedEvent`). |
+| Service | `QueueService` | Implements `IQueueService`. Sends single messages, batches, and receives from queues. Supports connection string and `TokenCredential` authentication. |
+| Service | `TopicService` | Implements `ITopicService`. Sends single messages, batches, and receives from topics/subscriptions. Supports connection string and `TokenCredential` authentication. |
+
+### Key Methods — `QueueService`
+
+- `SendMessageAsync(ServiceBusMessage)` — Sends a single message to the queue.
+- `SendMessageBatchAsync(Queue<ServiceBusMessage>, CancellationToken)` — Sends a batch of messages.
+- `ReceiveMessagesAsync(CancellationToken)` — Receives and processes messages from the queue.
+
+### Key Methods — `TopicService`
+
+- `SendMessageToTopicAsync(ServiceBusMessage, CancellationToken)` — Sends a single message to the topic.
+- `SendMessageBatchToTopicAsync(Queue<ServiceBusMessage>, CancellationToken)` — Sends a batch of messages.
+- `ReceiveFromSubscriptionAsync(CancellationToken)` — Receives and processes messages from a subscription.
+
+## Configuration
+
+No configuration model. Services are constructed directly with connection strings or `TokenCredential`.
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Azure.Messaging.ServiceBus` | Azure Service Bus client library |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.Storage.Tests/README.md
+++ b/src/CasCap.Api.Azure.Storage.Tests/README.md
@@ -7,7 +7,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ## Test Classes
 
 | Class | Description |
-| ----- | ----------- |
+| --- | --- |
 | `TestBase` | Abstract base configuring DI, logging, and Azurite connection string from `appsettings.Test.json`. |
 | `AzBlobStorageTests` | Integration tests for `AzBlobStorageBase` (container creation, upload, download, list, delete). |
 | `AzQueueStorageTests` | Integration tests for `AzQueueStorageBase` (enqueue, dequeue single/many). |
@@ -15,7 +15,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ## Test Services
 
 | Class | Description |
-| ----- | ----------- |
+| --- | --- |
 | `AzBlobService` | Concrete `AzBlobStorageBase` implementation for test blob operations. |
 | `AzQueueService` | Concrete `AzQueueStorageBase` implementation for test queue operations. |
 | `TestMessage` | Simple DTO with `Id`, `Dt`, and `TestString` used as a queue message payload. |
@@ -23,7 +23,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ## Test Interfaces
 
 | Interface | Description |
-| --------- | ----------- |
+| --- | --- |
 | `IAzBlobService` | Test-specific blob storage abstraction extending `IAzBlobStorageBase`. |
 | `IAzQueueService` | Test-specific queue storage abstraction extending `IAzQueueStorageBase`. |
 
@@ -31,20 +31,20 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Microsoft.NET.Test.Sdk` | .NET test SDK infrastructure |
-| `xunit` | xUnit testing framework |
-| `xunit.runner.visualstudio` | xUnit Visual Studio test runner |
-| `coverlet.collector` | Code coverage collector |
-| `coverlet.msbuild` | Code coverage MSBuild integration |
-| `Serilog.Sinks.XUnit` | Serilog sink for xUnit test output |
-| `Microsoft.Extensions.Configuration.Json` | JSON configuration file provider |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Testing` | Shared test utilities |
+| Package |
+| --- |
+| [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/microsoft.net.test.sdk) |
+| [xunit](https://www.nuget.org/packages/xunit) |
+| [xunit.runner.visualstudio](https://www.nuget.org/packages/xunit.runner.visualstudio) |
+| [coverlet.collector](https://www.nuget.org/packages/coverlet.collector) |
+| [coverlet.msbuild](https://www.nuget.org/packages/coverlet.msbuild) |
+| [Serilog.Sinks.XUnit](https://www.nuget.org/packages/serilog.sinks.xunit) |
+| [Microsoft.Extensions.Configuration.Json](https://www.nuget.org/packages/microsoft.extensions.configuration.json) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Testing](https://www.nuget.org/packages/cascap.common.testing) |
 
 ### Project References
 
 | Project | Description |
-| ------- | ----------- |
+| --- | --- |
 | `CasCap.Api.Azure.Storage` | The library under test |

--- a/src/CasCap.Api.Azure.Storage.Tests/README.md
+++ b/src/CasCap.Api.Azure.Storage.Tests/README.md
@@ -1,0 +1,50 @@
+# CasCap.Api.Azure.Storage.Tests
+
+xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover Blob Storage and Queue Storage operations against an Azurite emulator.
+
+> **Note:** Tests require the Azurite storage emulator running via `docker compose up -d` from the repository root. See the root [README.md](../../README.md) for details.
+
+## Test Classes
+
+| Class | Description |
+|-------|-------------|
+| `TestBase` | Abstract base configuring DI, logging, and Azurite connection string from `appsettings.Test.json`. |
+| `AzBlobStorageTests` | Integration tests for `AzBlobStorageBase` (container creation, upload, download, list, delete). |
+| `AzQueueStorageTests` | Integration tests for `AzQueueStorageBase` (enqueue, dequeue single/many). |
+
+## Test Services
+
+| Class | Description |
+|-------|-------------|
+| `AzBlobService` | Concrete `AzBlobStorageBase` implementation for test blob operations. |
+| `AzQueueService` | Concrete `AzQueueStorageBase` implementation for test queue operations. |
+| `TestMessage` | Simple DTO with `Id`, `Dt`, and `TestString` used as a queue message payload. |
+
+## Test Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| `IAzBlobService` | Test-specific blob storage abstraction extending `IAzBlobStorageBase`. |
+| `IAzQueueService` | Test-specific queue storage abstraction extending `IAzQueueStorageBase`. |
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Microsoft.NET.Test.Sdk` | .NET test SDK infrastructure |
+| `xunit` | xUnit testing framework |
+| `xunit.runner.visualstudio` | xUnit Visual Studio test runner |
+| `coverlet.collector` | Code coverage collector |
+| `coverlet.msbuild` | Code coverage MSBuild integration |
+| `Serilog.Sinks.XUnit` | Serilog sink for xUnit test output |
+| `Microsoft.Extensions.Configuration.Json` | JSON configuration file provider |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Testing` | Shared test utilities |
+
+### Project References
+
+| Project | Description |
+|---------|-------------|
+| `CasCap.Api.Azure.Storage` | The library under test |

--- a/src/CasCap.Api.Azure.Storage.Tests/README.md
+++ b/src/CasCap.Api.Azure.Storage.Tests/README.md
@@ -7,7 +7,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ## Test Classes
 
 | Class | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `TestBase` | Abstract base configuring DI, logging, and Azurite connection string from `appsettings.Test.json`. |
 | `AzBlobStorageTests` | Integration tests for `AzBlobStorageBase` (container creation, upload, download, list, delete). |
 | `AzQueueStorageTests` | Integration tests for `AzQueueStorageBase` (enqueue, dequeue single/many). |
@@ -15,7 +15,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ## Test Services
 
 | Class | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `AzBlobService` | Concrete `AzBlobStorageBase` implementation for test blob operations. |
 | `AzQueueService` | Concrete `AzQueueStorageBase` implementation for test queue operations. |
 | `TestMessage` | Simple DTO with `Id`, `Dt`, and `TestString` used as a queue message payload. |
@@ -23,7 +23,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ## Test Interfaces
 
 | Interface | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | `IAzBlobService` | Test-specific blob storage abstraction extending `IAzBlobStorageBase`. |
 | `IAzQueueService` | Test-specific queue storage abstraction extending `IAzQueueStorageBase`. |
 
@@ -32,7 +32,7 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Microsoft.NET.Test.Sdk` | .NET test SDK infrastructure |
 | `xunit` | xUnit testing framework |
 | `xunit.runner.visualstudio` | xUnit Visual Studio test runner |
@@ -46,5 +46,5 @@ xUnit integration tests for the `CasCap.Api.Azure.Storage` library. Tests cover 
 ### Project References
 
 | Project | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `CasCap.Api.Azure.Storage` | The library under test |

--- a/src/CasCap.Api.Azure.Storage/CasCap.Api.Azure.Storage.csproj
+++ b/src/CasCap.Api.Azure.Storage/CasCap.Api.Azure.Storage.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Description>Helper library for Azure Storage Services.</Description>
-    <PackageTags>azure,service,bus</PackageTags>
+    <Description>Helper library for Azure Blob, Queue, and Table storage operations.</Description>
+    <PackageTags>azure,storage,blob-storage,queue-storage,table-storage</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CasCap.Api.Azure.Storage/README.md
+++ b/src/CasCap.Api.Azure.Storage/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Storage Services. Provides abstract base service classe
 ## Services / Extensions
 
 | Type | Name | Description |
-| ---- | ---- | ----------- |
+| --- | --- | --- |
 | Interface | `IAzBlobStorageBase` | Contract for Azure Blob Storage container operations (upload, download, list, delete). |
 | Interface | `IAzQueueStorageBase` | Contract for Azure Queue Storage operations (enqueue, dequeue). |
 | Interface | `IAzTableStorageBase` | Contract for Azure Table Storage CRUD operations with batch support. |
@@ -47,16 +47,16 @@ No configuration model. Services are constructed directly with connection string
 
 ### NuGet Packages
 
-| Package | Description |
-| ------- | ----------- |
-| `Azure.Core` | Azure SDK core library |
-| `Azure.Storage.Blobs` | Azure Blob Storage client library |
-| `Azure.Storage.Queues` | Azure Queue Storage client library |
-| `Azure.Data.Tables` | Azure Table Storage client library |
-| `System.Linq.Async` | Async LINQ operators (net8.0 and net9.0 only) |
-| `CasCap.Common.Logging` | Shared logging infrastructure |
-| `CasCap.Common.Extensions` | Common extension methods |
-| `CasCap.Common.Serialization.Json` | JSON serialization helpers |
+| Package |
+| --- |
+| [Azure.Core](https://www.nuget.org/packages/azure.core) |
+| [Azure.Storage.Blobs](https://www.nuget.org/packages/azure.storage.blobs) |
+| [Azure.Storage.Queues](https://www.nuget.org/packages/azure.storage.queues) |
+| [Azure.Data.Tables](https://www.nuget.org/packages/azure.data.tables) |
+| [System.Linq.Async](https://www.nuget.org/packages/system.linq.async) |
+| [CasCap.Common.Logging](https://www.nuget.org/packages/cascap.common.logging) |
+| [CasCap.Common.Extensions](https://www.nuget.org/packages/cascap.common.extensions) |
+| [CasCap.Common.Serialization.Json](https://www.nuget.org/packages/cascap.common.serialization.json) |
 
 ### Project References
 

--- a/src/CasCap.Api.Azure.Storage/README.md
+++ b/src/CasCap.Api.Azure.Storage/README.md
@@ -1,0 +1,63 @@
+# CasCap.Api.Azure.Storage
+
+Helper library for Azure Storage Services. Provides abstract base service classes for Blob, Queue, and Table storage operations with both connection string and `TokenCredential` authentication.
+
+## Services / Extensions
+
+| Type | Name | Description |
+|------|------|-------------|
+| Interface | `IAzBlobStorageBase` | Contract for Azure Blob Storage container operations (upload, download, list, delete). |
+| Interface | `IAzQueueStorageBase` | Contract for Azure Queue Storage operations (enqueue, dequeue). |
+| Interface | `IAzTableStorageBase` | Contract for Azure Table Storage CRUD operations with batch support. |
+| Service | `AzBlobStorageBase` | Abstract base implementing `IAzBlobStorageBase`. Supports block blobs, page blobs, and append blobs. |
+| Service | `AzQueueStorageBase` | Abstract base implementing `IAzQueueStorageBase`. Handles Base64 message encoding and JSON serialization. |
+| Service | `AzTableStorageBase` | Abstract base implementing `IAzTableStorageBase`. Supports batch upsert, delete, and query with parallel partition processing. |
+| Extension | `LocalExtensions` | Extension methods for Table Storage key validation (`IsKeyValid`), `TableServiceClient.ExistsAsync`, and date-from-filename parsing. |
+| Message | `AzTableStorageArgs` | Event args for `BatchCompletedEvent`, carrying batch metadata (table name, partition key, count, remaining). |
+
+### Key Methods — `AzBlobStorageBase`
+
+- `CreateContainerIfNotExists(CancellationToken)` — Creates the blob container if it does not exist.
+- `DownloadBlobAsync(string blobName, CancellationToken)` — Downloads blob content as a byte array.
+- `ListContainerBlobs(string? prefix, CancellationToken)` — Lists blobs in the container.
+- `GetBlobPrefixes(string? prefix, CancellationToken)` — Retrieves virtual directory prefixes.
+- `DeleteBlob(string blobName, CancellationToken)` — Deletes a blob.
+- `PageBlobTest(string path, CancellationToken)` — Page blob creation and write test.
+
+### Key Methods — `AzQueueStorageBase`
+
+- `Enqueue<T>(T obj)` / `Enqueue<T>(List<T> objs)` — Serializes and enqueues messages.
+- `DequeueSingle<T>()` — Dequeues and deserializes a single message.
+- `DequeueMany<T>(int limit)` — Dequeues and deserializes multiple messages.
+
+### Key Methods — `AzTableStorageBase`
+
+- `GetTables(CancellationToken)` — Lists all tables in the storage account.
+- `GetTableClient(string tableName, bool CreateIfNotExists, CancellationToken)` — Gets a `TableClient` for a table.
+- `UploadData<T>(TableClient, List<T>, bool useParallelism, CancellationToken)` — Batch upsert entities.
+- `UpsertEntity<T>(string tableName, T entity, CancellationToken)` — Upserts a single entity.
+- `DeleteData<T>(TableClient, List<T>, CancellationToken)` — Batch delete entities.
+- `GetEntities<T>(TableClient, ...)` — Queries entities with optional filtering and paging.
+
+## Configuration
+
+No configuration model. Services are constructed directly with connection strings or `TokenCredential`.
+
+## Dependencies
+
+### NuGet Packages
+
+| Package | Description |
+|---------|-------------|
+| `Azure.Core` | Azure SDK core library |
+| `Azure.Storage.Blobs` | Azure Blob Storage client library |
+| `Azure.Storage.Queues` | Azure Queue Storage client library |
+| `Azure.Data.Tables` | Azure Table Storage client library |
+| `System.Linq.Async` | Async LINQ operators (net8.0 and net9.0 only) |
+| `CasCap.Common.Logging` | Shared logging infrastructure |
+| `CasCap.Common.Extensions` | Common extension methods |
+| `CasCap.Common.Serialization.Json` | JSON serialization helpers |
+
+### Project References
+
+None.

--- a/src/CasCap.Api.Azure.Storage/README.md
+++ b/src/CasCap.Api.Azure.Storage/README.md
@@ -5,7 +5,7 @@ Helper library for Azure Storage Services. Provides abstract base service classe
 ## Services / Extensions
 
 | Type | Name | Description |
-|------|------|-------------|
+| ---- | ---- | ----------- |
 | Interface | `IAzBlobStorageBase` | Contract for Azure Blob Storage container operations (upload, download, list, delete). |
 | Interface | `IAzQueueStorageBase` | Contract for Azure Queue Storage operations (enqueue, dequeue). |
 | Interface | `IAzTableStorageBase` | Contract for Azure Table Storage CRUD operations with batch support. |
@@ -48,7 +48,7 @@ No configuration model. Services are constructed directly with connection string
 ### NuGet Packages
 
 | Package | Description |
-|---------|-------------|
+| ------- | ----------- |
 | `Azure.Core` | Azure SDK core library |
 | `Azure.Storage.Blobs` | Azure Blob Storage client library |
 | `Azure.Storage.Queues` | Azure Queue Storage client library |


### PR DESCRIPTION
## Copilot Session Requests

- Add NuGet badge definitions and a badge table to the root README, matching the CasCap.Common pattern.
- Convert backtick NuGet package names to nuget.org hyperlinks and remove the Description column in all project README NuGet tables, aligning them with the single-column `| Package |` format used in CasCap.Common.
- Normalise table separator rows from `| ------- | ----------- |` to `| --- | --- |` (MD060).
- GitVersion.yml v5 → v6 migration (`ContinuousDeployment`, `label:`).
- Distribute `summarize-for-pr.prompt.md` Copilot prompt file.
- Ensure copilot-instructions.md is up to date with shared conventions.
- Update CI workflow (SonarQube references, `ubuntu-latest`).

## Commits

| Hash | Message | Author | Date |
| --- | --- | --- | --- |
| e506f7a | nuget updates | Alex Vincent | 2026-04-01 |
| 99480a2 | fix readmes | Alex Vincent | 2026-04-01 |
| c7040f1 | misc updates | Alex Vincent | 2026-04-01 |
| d681f47 | massive Comms refactor | Alex Vincent | 2026-04-01 |
| 088bcab | update instructions | Alex Vincent | 2026-03-31 |
| 92afa69 | update package tags +semver:feature | Alex Vincent | 2026-03-28 |
| 4873367 | updated readmes | Alex Vincent | 2026-03-28 |
| 9b8a94b | copilot instructions update | Alex Vincent | 2026-03-28 |
| b5d780c | AgentConfig -> AIConfig | Alex Vincent | 2026-03-26 |

## Files Changed

| File | Change | Insertions | Deletions |
| --- | --- | --- | --- |
| .github/copilot-instructions.md | Modified | 153 | 3 |
| .github/prompts/summarize-for-pr.prompt.md | Added | 62 | 0 |
| .github/workflows/ci.yml | Modified | 9 | 5 |
| Directory.Packages.props | Modified | 9 | 9 |
| GitVersion.yml | Modified | 5 | 5 |
| README.md | Modified | 142 | 0 |
| src/CasCap.Api.Azure.AppInsights/CasCap.Api.Azure.AppInsights.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.AppInsights/README.md | Added | 28 | 0 |
| src/CasCap.Api.Azure.CognitiveServices/CasCap.Api.Azure.CognitiveServices.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.CognitiveServices/README.md | Added | 36 | 0 |
| src/CasCap.Api.Azure.ContainerRegistry/CasCap.Api.Azure.ContainerRegistry.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.ContainerRegistry/README.md | Added | 32 | 0 |
| src/CasCap.Api.Azure.EventGrid/CasCap.Api.Azure.EventGrid.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.EventGrid/README.md | Added | 27 | 0 |
| src/CasCap.Api.Azure.EventHub/CasCap.Api.Azure.EventHub.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.EventHub/README.md | Added | 44 | 0 |
| src/CasCap.Api.Azure.LogAnalytics/CasCap.Api.Azure.LogAnalytics.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.LogAnalytics/README.md | Added | 38 | 0 |
| src/CasCap.Api.Azure.ServiceBus/CasCap.Api.Azure.ServiceBus.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.ServiceBus/README.md | Added | 43 | 0 |
| src/CasCap.Api.Azure.Storage.Tests/README.md | Added | 50 | 0 |
| src/CasCap.Api.Azure.Storage/CasCap.Api.Azure.Storage.csproj | Modified | 2 | 2 |
| src/CasCap.Api.Azure.Storage/README.md | Added | 63 | 0 |

_23 files changed, 757 insertions, 38 deletions._

## Change Details

### Copilot Instructions

1. Expanded `.github/copilot-instructions.md` from a minimal stub to the full shared CasCap convention set covering C#/.NET style, XML documentation, logging, GitHub Actions, MCP, documentation, and configuration sync rules.

### CI Workflow

1. Updated `.github/workflows/ci.yml` — commented-out SonarQube section updated to use `@v2` with kebab-case inputs and `ubuntu-latest` runner.

### GitVersion Configuration

1. Migrated `GitVersion.yml` from v5 to v6 format — `MainLine` → `ContinuousDeployment`, `tag:` → `label:`, unquoted `source-branches`.

### NuGet Package Versions

1. Updated `Directory.Packages.props` — bumped 9 package versions to latest stable releases.

### Root README

1. Added NuGet badge reference definitions for all 8 published library packages.
2. Added a `| Library | Package |` table with clickable version badges (matching the CasCap.Common root README pattern).
3. Normalised table separator rows to `| --- |`.

### Project READMEs (10 new files)

All 9 project READMEs are newly created, documenting each library's purpose, services/extensions, configuration, and dependencies. The test project README documents test classes, services, and interfaces.

1. Each README follows the CasCap.Common per-project pattern: Title → Purpose → Services/Extensions table → Configuration table → Dependencies (NuGet + Project references).
2. NuGet package names are hyperlinked to nuget.org (e.g. `[Azure.Data.Tables](https://www.nuget.org/packages/azure.data.tables)`).
3. NuGet tables use a single `| Package |` column without version numbers or descriptions.
4. All table separators use the spaced `| --- |` format (MD060 compliant).

### Project Files (8 .csproj)

1. Updated `PackageTags` property in all 8 library `.csproj` files — added `+semver:feature` tag and standardised tag lists.

### Copilot Prompt File

1. Added `.github/prompts/summarize-for-pr.prompt.md` — reusable prompt for generating PR change summaries.