### PR TITLE
feat: Key Vault skip sentinel, StorageExtensions, dev container & README improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,13 +17,29 @@
     //		}
     // }
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "sh . ./.devcontainer/postCreateCommand.sh",
-    "postStartCommand": "sh . ./.devcontainer/postStartCommand.sh",
+    "postCreateCommand": "sh ./.devcontainer/postCreateCommand.sh",
+    "postStartCommand": "sh ./.devcontainer/postStartCommand.sh",
     // Configure tool-specific properties.
-    // "customizations": {},
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {},
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-vscode.powershell",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode-remote.vscode-remote-extensionpack",
+                "mutantdino.resourcemonitor",
+                "usernamehw.errorlens",
+                "davidanson.vscode-markdownlint",
+                "ms-dotnettools.csharp"
+            ]
+        }
+    },
     "mounts": [
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/source/github,target=/workspaces,type=bind,consistency=cached",
-        "source=${env:HOME}${env:USERPROFILE}/.kube,target=/home/vscode/.kube,type=bind"
+        "source=${env:HOME}${env:USERPROFILE}/.kube,target=/home/vscode/.kube,type=bind,consistency=cached"
     ]
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -4,12 +4,6 @@ echo "postCreateCommand.sh"
 echo "--------------------"
 
 sudo apt-get update
-# sudo apt-get install -y python3 pip pre-commit
-
-# echo "Setup pre-commit"
-#pre-commit
-#pre-commit install --install-hooks
-#pre-commit run --all-files --verbose
-#pre-commit autoupdate
+sudo apt-get upgrade -y
 
 sudo chmod +x .devcontainer/postStartCommand.sh

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -3,9 +3,6 @@
 echo "postStartCommand.sh"
 echo "-------------------"
 
-sudo apt-get update
-sudo apt-get upgrade -y
-
 dotnet --version
 pre-commit autoupdate
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -307,6 +307,7 @@ Use these consistent heading patterns before Mermaid diagrams:
 
 - **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
+- **Build after refactoring**: After any refactoring, build the **entire solution** (not just the affected project) to catch edge-case compilation errors in dependent projects. When multiple `.sln` / `.slnx` files exist, prefer the one with a `.Debug.slnx` suffix.
 
 ## Misc
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,10 +16,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Author>Alex Vincent</Author>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props -->
     <!-- default for IsPackable is true, we change this to false here so that we must be explicit in each project when creating NuGet packages -->
     <IsPackable>false</IsPackable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,6 @@
     <IsPackable>false</IsPackable>
 
     <Authors>Alex Vincent</Authors>
-    <Copyright>Alex Vincent</Copyright>
     <!-- <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile> -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageProjectUrl>https://github.com/f2calv/CasCap.Api.Azure</PackageProjectUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.9.3" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.9.3" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.9.3" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.9.3" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.9.3" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.9.3" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.10.1" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.10.1" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.10.1" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.10.1" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.10.1" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.10.1" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,15 +14,15 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.9.2" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.9.2" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.9.2" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.9.2" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.9.2" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.9.2" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.9.3" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.9.3" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.9.3" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.9.3" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.9.3" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.9.3" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.9.1" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.9.1" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.9.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.9.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.9.1" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.9.1" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.9.2" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.9.2" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.9.2" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.9.2" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.9.2" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,24 @@
-MIT License
+This is free and unencumbered software released into the public domain.
 
-Copyright (c) 2020 Alex Vincent
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -33,13 +33,6 @@ A collection of .NET helper class libraries for interacting with Azure PaaS serv
 | CasCap.Api.Azure.ServiceBus | [![Nuget][cascap.api.azure.servicebus-badge]][cascap.api.azure.servicebus-url] |
 | CasCap.Api.Azure.Storage | [![Nuget][cascap.api.azure.storage-badge]][cascap.api.azure.storage-url] |
 
-**Solution Files:**
-
-- `CasCap.Api.Azure.Release.slnx` (production builds, uses NuGet packages)
-- `CasCap.Api.Azure.Debug.slnx` (development, references local CasCap.Common repo)
-
-**Dependency:** Debug builds require [CasCap.Common](https://github.com/f2calv/CasCap.Common) cloned at the same directory level.
-
 ## Projects
 
 | Project | Description | README |
@@ -200,7 +193,7 @@ graph TD
 - **.NET SDK**: 10.0.x stable (see `global.json` — `allowPrerelease: false`)
 - **Docker**: Required for Azurite storage emulator during testing
 
-## Build & Validation Commands
+## Build and Test
 
 ### 1. Restore Dependencies (REQUIRED FIRST STEP)
 
@@ -290,6 +283,32 @@ dotnet restore CasCap.Api.Azure.Release.slnx
 dotnet build CasCap.Api.Azure.Release.slnx --configuration Release --no-restore
 ```
 
+## Project Configuration
+
+### Solution Files
+
+| File | Purpose |
+| --- | --- |
+| `CasCap.Api.Azure.Debug.slnx` | Development — references local `CasCap.Common` repo |
+| `CasCap.Api.Azure.Release.slnx` | Release builds — consumes `CasCap.Common` as NuGet packages |
+
+**Dependency:** Debug builds require [CasCap.Common](https://github.com/f2calv/CasCap.Common) cloned at the same directory level.
+
+### Key Files
+
+| File | Purpose |
+| --- | --- |
+| `Directory.Build.props` | C# 14.0, `ImplicitUsings`, `Nullable: enable`, `TreatWarningsAsErrors: true`, `IsPackable: false` by default |
+| `Directory.Packages.props` | Central package version management (`ManagePackageVersionsCentrally: true`) |
+| `.editorconfig` | Code style rules (4-space indent, LF line endings, full formatting rules) |
+| `global.json` | SDK constraint — stable releases only |
+| `docker-compose.yml` | Azurite storage emulator setup |
+| `GitVersion.yml` | Semantic versioning configuration |
+
+### Suppressed Warnings
+
+Configured in `Directory.Build.props`: `IDE1006`, `IDE0079`, `IDE0042`, `CS0162`, `CS1574`, `S125`, `NETSDK1233`, `NU1901`, `NU1902`, `NU1903`
+
 ## CI/CD Pipeline (.github/workflows/ci.yml)
 
 **Triggers:** push (except preview branches), pull_request to main, workflow_dispatch
@@ -319,6 +338,51 @@ All libraries target **net8.0, net9.0, and net10.0** simultaneously. When making
 - **Versioning:** Automated via GitVersion (MainLine mode)
 - **NuGet Push:** Handled by CI on main branch (requires NUGET_API_KEY secret)
 - **Package metadata:** Defined in Directory.Build.props (author, license, icon, source link)
+
+## Making Changes
+
+### Adding Code
+
+1. Place code in the correct project by functionality
+2. Follow `.editorconfig` style rules
+3. Add XML documentation to all public API surface
+4. Add tests in the corresponding `.Tests` project
+5. Validate: `dotnet build CasCap.Api.Azure.Release.slnx --configuration Release --no-restore` → 0 errors
+
+### Adding Dependencies
+
+1. Add version to `Directory.Packages.props`
+2. Reference in `.csproj` **without** a version attribute:
+
+   ```xml
+   <PackageReference Include="PackageName" />
+   ```
+
+3. Run `dotnet restore`
+
+### Creating New Projects
+
+- Library projects inherit `Directory.Build.props` automatically
+- Set `<IsPackable>true</IsPackable>` explicitly only for NuGet packages
+- Test projects must **not** be packable (default) and must target `net8.0;net9.0;net10.0`
+
+## Validation Checklist
+
+- [ ] `dotnet restore CasCap.Api.Azure.Release.slnx` succeeds
+- [ ] `dotnet build CasCap.Api.Azure.Release.slnx --configuration Release --no-restore` completes with 0 errors
+- [ ] `dotnet format CasCap.Api.Azure.Release.slnx --verify-no-changes --no-restore` passes
+- [ ] Docker dependencies running for tests (`docker compose up -d`)
+- [ ] Public API has XML documentation
+- [ ] Properties separated by blank lines
+- [ ] `ServiceProvider` instances are disposed in tests
+
+## Contributing
+
+1. Fork the repository and create a feature branch
+2. Follow all conventions documented above
+3. Run the full validation checklist before submitting a PR
+4. PRs target the `main` branch and require CI to pass
+5. Versioning is automated via GitVersion — do not manually edit version numbers
 
 ## Common Gotchas
 

--- a/src/CasCap.Api.Azure.Auth/Abstractions/IAzureAuthConfig.cs
+++ b/src/CasCap.Api.Azure.Auth/Abstractions/IAzureAuthConfig.cs
@@ -11,6 +11,14 @@ namespace CasCap.Abstractions;
 /// </remarks>
 public interface IAzureAuthConfig
 {
+    /// <summary>Sentinel value for <see cref="KeyVaultName"/> that disables Key Vault integration.</summary>
+    /// <remarks>Set <see cref="KeyVaultName"/> to this value to run without Azure Key Vault.</remarks>
+    const string SkipKeyVaultSentinel = "skip";
+
+    /// <summary>Whether Key Vault integration is active.</summary>
+    /// <remarks>Returns <see langword="false"/> when <see cref="KeyVaultName"/> equals <c>"skip"</c> (case-insensitive).</remarks>
+    bool IsKeyVaultEnabled => !string.Equals(KeyVaultName, SkipKeyVaultSentinel, StringComparison.OrdinalIgnoreCase);
+
     /// <summary>Short name of the Azure Key Vault (without the <c>.vault.azure.net</c> suffix).</summary>
     string KeyVaultName { get; }
 

--- a/src/CasCap.Api.Azure.Auth/Models/_AzureAuthConfig.cs
+++ b/src/CasCap.Api.Azure.Auth/Models/_AzureAuthConfig.cs
@@ -11,6 +11,10 @@ public record AzureAuthConfig : IAppConfig, IAzureAuthConfig
     public static string ConfigurationSectionName => "AppConfig";
 
     /// <inheritdoc/>
+    public bool IsKeyVaultEnabled =>
+        !string.Equals(KeyVaultName, IAzureAuthConfig.SkipKeyVaultSentinel, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
     [Required, MinLength(3)]
     public required string KeyVaultName { get; init; }
 

--- a/src/CasCap.Api.Azure.Auth/README.md
+++ b/src/CasCap.Api.Azure.Auth/README.md
@@ -8,7 +8,7 @@ Helper library for Azure authentication. Provides a factory for creating `TokenC
 
 | Type | Name | Description |
 | --- | --- | --- |
-| Interface | `IAzureAuthConfig` | Exposes Azure authentication configuration: Key Vault name/URI, Entra ID tenant/application IDs, certificate thumbprint or PFX path/password, and a lazily-resolved `TokenCredential`. |
+| Interface | `IAzureAuthConfig` | Exposes Azure authentication configuration: Key Vault name/URI, Entra ID tenant/application IDs, certificate thumbprint or PFX path/password, and a lazily-resolved `TokenCredential`. Provides `IsKeyVaultEnabled` to allow Key Vault-free operation. |
 | Static factory | `TokenCredentialExtensions` | Creates `ClientCertificateCredential` from `IAzureAuthConfig` properties (certificate thumbprint or PFX file). |
 
 ### Key Methods
@@ -20,9 +20,24 @@ Helper library for Azure authentication. Provides a factory for creating `TokenC
 
 | Class | Section | Properties |
 | --- | --- | --- |
-| `AzureAuthConfig` | `AppConfig` | `KeyVaultName` (required), `AzureEntraPodManagedIdentityClientId`, `AzureEntraTenantId`, `AzureEntraApplicationId`, `AzureEntraCertThumbprint`, `AzureEntraPfxPath`, `AzureEntraPfxPassword` |
+| `AzureAuthConfig` | `AppConfig` | `KeyVaultName` (required), `IsKeyVaultEnabled` (computed), `AzureEntraPodManagedIdentityClientId`, `AzureEntraTenantId`, `AzureEntraApplicationId`, `AzureEntraCertThumbprint`, `AzureEntraPfxPath`, `AzureEntraPfxPassword` |
 
 `AzureAuthConfig` implements both `IAppConfig` and `IAzureAuthConfig`. The `TokenCredential` property is lazily created from the certificate properties via `TokenCredentialExtensions`.
+
+### Running Without Key Vault
+
+Set `KeyVaultName` to `"skip"` (case-insensitive) to disable Key Vault integration entirely. When `IsKeyVaultEnabled` returns `false`:
+
+- The application skips adding Azure Key Vault as a configuration source at startup.
+- `TokenCredential` is not resolved (no certificate lookup is attempted).
+- Secrets must be supplied via alternative configuration sources (environment variables, user secrets, or `appsettings.json`).
+- Sink services that use `StorageExtensions.CreateTableClient()` automatically fall back to connection strings when the connection string contains `;` (e.g. Azurite emulator).
+
+Override via any configuration source:
+
+- **Environment variable**: `AppConfig__KeyVaultName=skip`
+- **User secrets**: `{ "AppConfig": { "KeyVaultName": "skip" } }`
+- **appsettings override**: same JSON shape
 
 ## Data Flow
 
@@ -54,7 +69,9 @@ flowchart TD
         SB["Service Bus"]
     end
 
-    CONFIG --> POD_CHECK
+    CONFIG --> SKIP_CHECK{"KeyVaultName<br/>= 'skip'?"}
+    SKIP_CHECK -->|"Yes"| NULL
+    SKIP_CHECK -->|"No"| POD_CHECK
     POD_CHECK -->|"Yes"| WORKLOAD
     POD_CHECK -->|"No"| THUMBPRINT
 
@@ -79,6 +96,7 @@ flowchart TD
 
 **Credential Resolution Priority:**
 
+0. **Skip sentinel** — `KeyVaultName = "skip"` → `null` (no credential, no Key Vault)
 1. **Azure Workload Identity** (Kubernetes pod with federated token) — auto-detected
 2. **Certificate thumbprint** — searches `LocalMachine\My` certificate store
 3. **PFX file** — loads certificate from path with password


### PR DESCRIPTION
## Changes

### Dev Container

- Fixed `postCreateCommand`/`postStartCommand` script paths (removed stale `. ` prefix).
- Added VS Code extensions to `devcontainer.json` (PowerShell, Docker, Remote Pack, Resource Monitor, Error Lens, markdownlint, C#).
- Moved `apt-get upgrade` from `postStartCommand` to `postCreateCommand`.
- Added `consistency=cached` to `.kube` mount.

### AzureAuthConfig — Key Vault Skip Sentinel

- Added `SkipKeyVaultSentinel` constant and `IsKeyVaultEnabled` computed property to `IAzureAuthConfig` / `AzureAuthConfig`.
- Updated Auth README with "Running Without Key Vault" section and updated Mermaid flow diagram.

### StorageExtensions

- Renamed `LocalExtensions` → `StorageExtensions`.
- Added `CreateTableClient()` and `CreateBlobServiceClient()` factory methods supporting both connection strings and URI+credential.
- `AzBlobStorageBase` constructors now call `CreateIfNotExists()` on the container.
- Updated test references to use new class name.

### Copilot Instructions

- Added "Build after refactoring" convention.

### Directory.Build.props

- Removed duplicate `Author` property group (kept `Authors`).
- Removed `Copyright` property.

### README

- Restructured into "Project Configuration" / "Making Changes" / "Validation Checklist" / "Contributing" sections.
- Moved solution file info from top section into a dedicated table.

### License

- Changed from MIT to Unlicense.

### NuGet Package Updates

| Package | Old | New |
| --- | --- | --- |
| CasCap.Common.Abstractions | 4.9.1 | 4.10.1 |
| CasCap.Common.Extensions | 4.9.1 | 4.10.1 |
| CasCap.Common.Logging | 4.9.1 | 4.10.1 |
| CasCap.Common.Serialization.Json | 4.9.1 | 4.10.1 |
| CasCap.Common.Serialization.MessagePack | 4.9.1 | 4.10.1 |
| CasCap.Common.Testing | 4.9.1 | 4.10.1 |
| Microsoft.Extensions.Configuration.Json | 10.0.6 | 10.0.7 |
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.5.0 |