### PR TITLE
chore: bump NuGet packages & fix Options→Config comment references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Core" Version="1.53.0" />
+    <PackageVersion Include="Azure.Core" Version="1.54.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,15 +14,15 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.10.1" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.10.1" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.10.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.10.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.10.1" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.10.1" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.10.4" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.10.4" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.10.4" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.10.4" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.10.4" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.10.4" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />

--- a/src/CasCap.Api.Azure.AppInsights/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CasCap.Api.Azure.AppInsights/Extensions/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     public static void AddCasCapAppInsightsServices(this IServiceCollection services/*,
-            Action<AppInsightsOptions> appInsights*/)
+            Action<LogAnalyticsConfig> appInsights*/)
     {
         services.AddSingleton<IConfigureOptions<AppInsightsConfig>>(s =>
         {

--- a/src/CasCap.Api.Azure.LogAnalytics/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CasCap.Api.Azure.LogAnalytics/Extensions/ServiceCollectionExtensions.cs
@@ -9,11 +9,11 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers the Log Analytics configuration options and the <see cref="IQueryService"/>
     /// implementation with the dependency injection container.
-    /// Options are bound from the <c>CasCap:LogAnalyticsOptions</c> configuration section.
+    /// Options are bound from the <c>CasCap:LogAnalyticsConfig</c> configuration section.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
     public static void AddCasCapLogAnalyticsServices(this IServiceCollection services/*,
-            Action<LogAnalyticsOptions> LogAnalytics*/)
+            Action<LogAnalyticsConfig> LogAnalytics*/)
     {
         services.AddSingleton<IConfigureOptions<LogAnalyticsConfig>>(s =>
         {
@@ -22,6 +22,6 @@ public static class ServiceCollectionExtensions
         });
         services.AddSingleton<IQueryService, QueryService>();
         //services.AddSingleton<ILogAnalyticsService, LogAnalyticsService>()
-        //    .Configure<LogAnalyticsOptions>(configuration.GetSection(nameof(LogAnalyticsOptions)));
+        //    .Configure<LogAnalyticsConfig>(configuration.GetSection(nameof(LogAnalyticsConfig)));
     }
 }


### PR DESCRIPTION
## Changes

### NuGet Package Updates

| Package | Old | New |
| --- | --- | --- |
| Azure.Core | 1.53.0 | 1.54.0 |
| CasCap.Common.Abstractions | 4.10.1 | 4.10.4 |
| CasCap.Common.Extensions | 4.10.1 | 4.10.4 |
| CasCap.Common.Logging | 4.10.1 | 4.10.4 |
| CasCap.Common.Serialization.Json | 4.10.1 | 4.10.4 |
| CasCap.Common.Serialization.MessagePack | 4.10.1 | 4.10.4 |
| CasCap.Common.Testing | 4.10.1 | 4.10.4 |
| Microsoft.NET.Test.Sdk | 18.5.0 | 18.5.1 |

### Comment Cleanup

- Updated stale `Options`-suffixed class references in commented-out code to use the current `Config`-suffixed names (`AppInsightsConfig`, `LogAnalyticsConfig`).