### PR TITLE
chore: bump CasCap.Common packages 4.10.4 → 4.10.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.10.4" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.10.4" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.10.4" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.10.4" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.10.4" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.10.4" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.10.5" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.10.5" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.10.5" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.10.5" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.10.5" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.10.5" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />


### PR DESCRIPTION
## NuGet Package Updates

| Package | Old | New |
| --- | --- | --- |
| CasCap.Common.Abstractions | 4.10.4 | 4.10.5 |
| CasCap.Common.Extensions | 4.10.4 | 4.10.5 |
| CasCap.Common.Logging | 4.10.4 | 4.10.5 |
| CasCap.Common.Serialization.Json | 4.10.4 | 4.10.5 |
| CasCap.Common.Serialization.MessagePack | 4.10.4 | 4.10.5 |
| CasCap.Common.Testing | 4.10.4 | 4.10.5 |