### PR TITLE
Add CancellationToken support, bump dependencies, update packaging metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,8 +24,10 @@
     <!-- <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile> -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageProjectUrl>https://github.com/f2calv/CasCap.Api.Azure</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
+    <Copyright>Copyright (c) Alex Vincent 2026</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>See https://github.com/f2calv/CasCap.Api.Azure/releases</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.10.5" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.10.5" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.10.5" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.10.5" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.10.5" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.10.5" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.0" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.0" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.0" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.0" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.0" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Core" Version="1.54.0" />
+    <PackageVersion Include="Azure.Core" Version="1.55.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />

--- a/src/CasCap.Api.Azure.AppInsights/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.AppInsights/GlobalUsings.cs
@@ -1,3 +1,3 @@
-﻿global using CasCap.Models;
+global using CasCap.Models;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.Options;

--- a/src/CasCap.Api.Azure.AppInsights/README.md
+++ b/src/CasCap.Api.Azure.AppInsights/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Application Insights. Provides configuration binding and DI registration for Application Insights instrumentation.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.AppInsights
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.Auth/README.md
+++ b/src/CasCap.Api.Azure.Auth/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure authentication. Provides a factory for creating `TokenCredential` instances from certificate-based configuration properties and an abstraction for Azure Key Vault and Entra ID settings.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.Auth
+```
+
 **Target frameworks:** `net8.0`, `net9.0`, `net10.0`
 
 ## Services / Extensions

--- a/src/CasCap.Api.Azure.CognitiveServices/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.CognitiveServices/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using Azure.Core;
+global using Azure.Core;
 global using CasCap.Abstractions;
 global using Microsoft.CognitiveServices.Speech;
 global using Microsoft.CognitiveServices.Speech.Audio;

--- a/src/CasCap.Api.Azure.CognitiveServices/README.md
+++ b/src/CasCap.Api.Azure.CognitiveServices/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Cognitive Services. Provides text-to-speech synthesis and speech-to-text recognition via the Azure Speech SDK.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.CognitiveServices
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.ContainerRegistry/README.md
+++ b/src/CasCap.Api.Azure.ContainerRegistry/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Container Registry. Provides a base service class for listing repositories and manifests.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.ContainerRegistry
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.EventGrid/README.md
+++ b/src/CasCap.Api.Azure.EventGrid/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Event Grid. Provides foundational package references for Event Grid messaging integration.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.EventGrid
+```
+
 > **Note:** This project currently contains no service classes or interfaces. It serves as a packaging placeholder with the `Azure.Messaging.EventGrid` SDK dependency ready for consumption by downstream projects.
 
 ## Services / Extensions

--- a/src/CasCap.Api.Azure.EventHub/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.EventHub/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using Azure.Core;
+global using Azure.Core;
 global using Azure.Messaging.EventHubs;
 global using Azure.Messaging.EventHubs.Consumer;
 global using Azure.Messaging.EventHubs.Processor;

--- a/src/CasCap.Api.Azure.EventHub/README.md
+++ b/src/CasCap.Api.Azure.EventHub/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Event Hub. Provides generic publisher and subscriber base services for streaming events via Event Hubs, with MessagePack serialization.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.EventHub
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.LogAnalytics/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.LogAnalytics/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using Azure.Core;
+global using Azure.Core;
 global using Azure.Monitor.Query;
 global using CasCap.Abstractions;
 global using CasCap.Models;

--- a/src/CasCap.Api.Azure.LogAnalytics/README.md
+++ b/src/CasCap.Api.Azure.LogAnalytics/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Log Analytics. Provides a query service for retrieving Application Insights exception data via Azure Monitor Log Analytics, with DI registration and configuration binding.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.LogAnalytics
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.ServiceBus/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.ServiceBus/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using Azure.Core;
+global using Azure.Core;
 global using Azure.Messaging.ServiceBus;
 global using CasCap.Abstractions;
 global using CasCap.Common.Exceptions;

--- a/src/CasCap.Api.Azure.ServiceBus/README.md
+++ b/src/CasCap.Api.Azure.ServiceBus/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Service Bus. Provides base service classes for queue and topic send/receive operations with event-driven message handling.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.ServiceBus
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.Storage.Tests/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.Storage.Tests/GlobalUsings.cs
@@ -5,7 +5,5 @@ global using CasCap.Services;
 global using CasCap.Tests.Abstractions;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Diagnostics;
 global using Xunit;
-global using Xunit.Abstractions;

--- a/src/CasCap.Api.Azure.Storage/Abstractions/IAzQueueStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Abstractions/IAzQueueStorageBase.cs
@@ -5,27 +5,31 @@ public interface IAzQueueStorageBase
 {
     /// <summary>Dequeues and deserializes a single message from the queue.</summary>
     /// <typeparam name="T">The type to deserialize the message body into.</typeparam>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>
     /// A tuple containing the deserialized object (or <see langword="null"/> if deserialization failed)
     /// and the raw <see cref="QueueMessage"/> that was dequeued.
     /// </returns>
-    Task<(T? obj, QueueMessage message)> DequeueSingle<T>() where T : class;
+    Task<(T? obj, QueueMessage message)> DequeueSingle<T>(CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>Dequeues and deserializes multiple messages from the queue.</summary>
     /// <typeparam name="T">The type to deserialize each message body into.</typeparam>
     /// <param name="limit">The maximum number of messages to dequeue. Defaults to 1.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A list of deserialized objects retrieved from the queue.</returns>
-    Task<List<T>> DequeueMany<T>(int limit = 1) where T : class;
+    Task<List<T>> DequeueMany<T>(int limit = 1, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>Serializes and enqueues a single object onto the queue.</summary>
     /// <typeparam name="T">The type of the object to enqueue.</typeparam>
     /// <param name="obj">The object to serialize and add to the queue.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns><see langword="true"/> if the message was successfully enqueued; otherwise, <see langword="false"/>.</returns>
-    Task<bool> Enqueue<T>(T obj) where T : class;
+    Task<bool> Enqueue<T>(T obj, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>Serializes and enqueues a collection of objects onto the queue.</summary>
     /// <typeparam name="T">The type of the objects to enqueue.</typeparam>
     /// <param name="objs">The list of objects to serialize and add to the queue.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns><see langword="true"/> if at least one message was successfully enqueued; otherwise, <see langword="false"/>.</returns>
-    Task<bool> Enqueue<T>(List<T> objs) where T : class;
+    Task<bool> Enqueue<T>(List<T> objs, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/CasCap.Api.Azure.Storage/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.Storage/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using Azure;
+global using Azure;
 global using Azure.Core;
 global using Azure.Data.Tables;
 global using Azure.Data.Tables.Models;

--- a/src/CasCap.Api.Azure.Storage/README.md
+++ b/src/CasCap.Api.Azure.Storage/README.md
@@ -2,6 +2,12 @@
 
 Helper library for Azure Storage Services. Provides abstract base service classes for Blob, Queue, and Table storage operations with both connection string and `TokenCredential` authentication.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Api.Azure.Storage
+```
+
 ## Services / Extensions
 
 | Type | Name | Description |

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
@@ -32,20 +32,20 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
 
     private bool _haveCheckedIfQueueExists = false;
 
-    private async ValueTask CreateQueueIfNotExistsAsync()
+    private async ValueTask CreateQueueIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
-        if (!_haveCheckedIfQueueExists && (await _queueClient.CreateIfNotExistsAsync() is not null))
+        if (!_haveCheckedIfQueueExists && (await _queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken) is not null))
             _logger.LogDebug("{ClassName} storage queue didn't exist so have now created {QueueName}", nameof(AzQueueStorageBase), _queueClient.Name);
         _haveCheckedIfQueueExists = true;
     }
 
     /// <inheritdoc/>
-    public Task<bool> Enqueue<T>(T obj) where T : class => Enqueue([obj]);
+    public Task<bool> Enqueue<T>(T obj, CancellationToken cancellationToken = default) where T : class => Enqueue([obj], cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<bool> Enqueue<T>(List<T> objs) where T : class
+    public async Task<bool> Enqueue<T>(List<T> objs, CancellationToken cancellationToken = default) where T : class
     {
-        await CreateQueueIfNotExistsAsync();
+        await CreateQueueIfNotExistsAsync(cancellationToken);
         var i = 1;
         foreach (var obj in objs)
         {
@@ -59,7 +59,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             Azure.Response<SendReceipt>? result = null;
             try
             {
-                result = await _queueClient.SendMessageAsync(message);
+                result = await _queueClient.SendMessageAsync(message, default, default, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -77,12 +77,12 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     }
 
     /// <inheritdoc/>
-    public async Task<(T?, QueueMessage)> DequeueSingle<T>() where T : class
+    public async Task<(T?, QueueMessage)> DequeueSingle<T>(CancellationToken cancellationToken = default) where T : class
     {
         //_logger.LogTrace("{ClassName} trying account {AccountName}...", nameof(AzQueueStorageBase), _queueClient.AccountName);
-        await CreateQueueIfNotExistsAsync();
+        await CreateQueueIfNotExistsAsync(cancellationToken);
         // Get the next message
-        var retrievedMessage = await _queueClient.ReceiveMessageAsync();
+        var retrievedMessage = await _queueClient.ReceiveMessageAsync(cancellationToken: cancellationToken);
         if (retrievedMessage is not null && retrievedMessage.Value is not null)
         {
             var json = retrievedMessage.Value.Body.ToString();
@@ -99,7 +99,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             }
             finally
             {
-                _ = await _queueClient.DeleteMessageAsync(retrievedMessage.Value.MessageId, retrievedMessage.Value.PopReceipt);
+                _ = await _queueClient.DeleteMessageAsync(retrievedMessage.Value.MessageId, retrievedMessage.Value.PopReceipt, cancellationToken);
                 if (IsCorrupted)
                     _logger.LogWarning("{ClassName} removed message id {Id} from queue as it failed deserialization, '{Json}'",
                         nameof(AzQueueStorageBase), retrievedMessage.Value.MessageId, json);
@@ -114,10 +114,10 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     }
 
     /// <inheritdoc/>
-    public async Task<List<T>> DequeueMany<T>(int limit = 1) where T : class
+    public async Task<List<T>> DequeueMany<T>(int limit = 1, CancellationToken cancellationToken = default) where T : class
     {
-        await CreateQueueIfNotExistsAsync();
-        var messages = await Dequeue(limit);
+        await CreateQueueIfNotExistsAsync(cancellationToken);
+        var messages = await Dequeue(limit, cancellationToken);
         var l = new List<T>(messages.Count);
         foreach (var retrievedMessage in messages)
         {
@@ -125,17 +125,17 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             var obj = json.FromJson<T>();
             l.Add(obj!);
             //delete each message after processing
-            await _queueClient.DeleteMessageAsync(retrievedMessage.MessageId, retrievedMessage.PopReceipt);
+            await _queueClient.DeleteMessageAsync(retrievedMessage.MessageId, retrievedMessage.PopReceipt, cancellationToken);
         }
         return l;
     }
 
-    private async Task<List<QueueMessage>> Dequeue(int limit = 1)
+    private async Task<List<QueueMessage>> Dequeue(int limit = 1, CancellationToken cancellationToken = default)
     {
-        var properties = await _queueClient.GetPropertiesAsync();
+        var properties = await _queueClient.GetPropertiesAsync(cancellationToken);
         if (properties.Value.ApproximateMessagesCount > 1) limit = properties.Value.ApproximateMessagesCount;
         var l = new List<QueueMessage>(limit);
-        var messages = await _queueClient.ReceiveMessagesAsync(limit);
+        var messages = await _queueClient.ReceiveMessagesAsync(limit, cancellationToken: cancellationToken);
         foreach (var retrievedMessage in messages.Value)
             l.Add(retrievedMessage);
         return l;


### PR DESCRIPTION
## Changes

### CancellationToken Support
- Added `CancellationToken` parameter to all `IAzQueueStorageBase` methods (`DequeueSingle`, `DequeueMany`, `Enqueue`) and their implementations in `AzQueueStorageBase`
- Propagated cancellation tokens through to underlying Azure SDK calls (`CreateIfNotExistsAsync`, `SendMessageAsync`)

### Dependency Updates
- Bumped `CasCap.Common.*` packages from `4.10.5` → `4.11.0`
- Bumped `Azure.Core` from `1.54.0` → `1.55.0`

### Packaging Metadata
- Changed `PackageLicenseExpression` from `MIT` → `Unlicense`
- Added `Copyright` property
- Added `PackageReleaseNotes` linking to GitHub releases

### Housekeeping
- Tidied `GlobalUsings.cs` files across projects (namespace alignment with CasCap.Common 4.11.0)
- Added `README.md` `PackageReadmeFile` entries to all sub-projects