### PR TITLE
chore: bump NuGet packages & skip lint on default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   lint:
+    if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
     uses: f2calv/gha-workflows/.github/workflows/lint.yml@v1
 
   versioning:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,15 +12,15 @@
     <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
     <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.2" />
     <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.2" />
     <PackageVersion Include="CasCap.Common.Logging" Version="4.11.2" />
     <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.2" />
     <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.2" />
     <PackageVersion Include="CasCap.Common.Testing" Version="4.11.2" />
-    <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
+    <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.50.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.1" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.1" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.1" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.1" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.1" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.2" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.2" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.2" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.2" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.2" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.2" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.0" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.0" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.0" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.0" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.0" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.0" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.1" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.1" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.1" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.1" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.1" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.1" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.2" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.2" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.2" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.2" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.2" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.2" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.3" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.3" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.3" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.3" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.3" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.3" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.50.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.2" />
     <PackageVersion Include="CasCap.Common.Testing" Version="4.11.2" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.49.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />


### PR DESCRIPTION
## Changes

### CI
- Skip the `lint` job on the default branch (run only on feature branches).

### NuGet Package Updates

| Package | Old | New |
| --- | --- | --- |
| Azure.Storage.Blobs | 12.27.0 | 12.28.0 |
| Azure.Storage.Queues | 12.25.0 | 12.26.0 |
| CasCap.Common.Abstractions | 4.11.0 | 4.11.3 |
| CasCap.Common.Extensions | 4.11.0 | 4.11.3 |
| CasCap.Common.Logging | 4.11.0 | 4.11.3 |
| CasCap.Common.Serialization.Json | 4.11.0 | 4.11.3 |
| CasCap.Common.Serialization.MessagePack | 4.11.0 | 4.11.3 |
| CasCap.Common.Testing | 4.11.0 | 4.11.3 |
| Microsoft.CognitiveServices.Speech | 1.49.1 | 1.50.0 |
| Microsoft.Extensions.Configuration.Json | 10.0.7 | 10.0.8 |