### PR TITLE
Add Stream-based UploadBlob overload + NuGet updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Core" Version="1.55.0" />
+    <PackageVersion Include="Azure.Core" Version="1.56.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />
@@ -14,19 +14,19 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.3" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.3" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.3" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.3" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.3" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.3" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.4" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.4" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.4" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.4" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.4" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.4" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.50.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/CasCap.Api.Azure.Storage/Abstractions/IAzBlobStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Abstractions/IAzBlobStorageBase.cs
@@ -46,6 +46,14 @@ public interface IAzBlobStorageBase
     Task UploadBlob(string blobName, byte[] bytes, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Uploads a stream to the container as a blob with the specified name, overwriting any existing blob.
+    /// </summary>
+    /// <param name="blobName">The name to assign to the uploaded blob.</param>
+    /// <param name="stream">The stream content to upload. The caller is responsible for disposing.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    Task UploadBlob(string blobName, Stream stream, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Runs a page blob write/read test by creating a 1 GB page blob and uploading the contents of the specified file.
     /// </summary>
     /// <param name="path">The local file path whose contents will be written to the page blob. Must be 4 MB or smaller.</param>

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
@@ -151,4 +151,11 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
         using var stream = new MemoryStream(bytes, writable: false);
         _ = await _blobClient.UploadAsync(stream, true, cancellationToken);
     }
+
+    /// <inheritdoc/>
+    public async Task UploadBlob(string blobName, Stream stream, CancellationToken cancellationToken)
+    {
+        var _blobClient = _containerClient.GetBlobClient(blobName);
+        _ = await _blobClient.UploadAsync(stream, true, cancellationToken);
+    }
 }


### PR DESCRIPTION
## Changes

### New Feature

- Added `UploadBlob(string blobName, Stream stream, CancellationToken cancellationToken)` overload to `IAzBlobStorageBase` and `AzBlobStorageBase` — allows uploading directly from a `Stream` without requiring the caller to materialise a `byte[]` first.

### NuGet Updates

| Package | Previous | New |
| --- | --- | --- |
| Azure.Core | 1.55.0 | 1.56.0 |
| CasCap.Common.* | 4.11.3 | 4.11.4 |
| coverlet.collector | 10.0.0 | 10.0.1 |
| coverlet.msbuild | 10.0.0 | 10.0.1 |