### PR TITLE
Azure Storage base classes: configurable ServiceVersion, bug fixes, and code quality improvements

### DIFF
--- a/src/CasCap.Api.Azure.Storage/Abstractions/IAzBlobStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Abstractions/IAzBlobStorageBase.cs
@@ -52,11 +52,4 @@ public interface IAzBlobStorageBase
     /// <param name="stream">The stream content to upload. The caller is responsible for disposing.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     Task UploadBlob(string blobName, Stream stream, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Runs a page blob write/read test by creating a 1 GB page blob and uploading the contents of the specified file.
-    /// </summary>
-    /// <param name="path">The local file path whose contents will be written to the page blob. Must be 4 MB or smaller.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    Task PageBlobTest(string path, CancellationToken cancellationToken = default);
 }

--- a/src/CasCap.Api.Azure.Storage/GlobalUsings.cs
+++ b/src/CasCap.Api.Azure.Storage/GlobalUsings.cs
@@ -12,5 +12,6 @@ global using CasCap.Common.Exceptions;
 global using CasCap.Common.Extensions;
 global using CasCap.Messages;
 global using Microsoft.Extensions.Logging;
+global using System.Collections.Concurrent;
 global using System.Globalization;
 global using System.Text.RegularExpressions;

--- a/src/CasCap.Api.Azure.Storage/README.md
+++ b/src/CasCap.Api.Azure.Storage/README.md
@@ -12,35 +12,35 @@ dotnet add package CasCap.Api.Azure.Storage
 
 | Type | Name | Description |
 | --- | --- | --- |
-| Interface | `IAzBlobStorageBase` | Contract for Azure Blob Storage container operations (upload, download, list, delete). |
-| Interface | `IAzQueueStorageBase` | Contract for Azure Queue Storage operations (enqueue, dequeue). |
-| Interface | `IAzTableStorageBase` | Contract for Azure Table Storage CRUD operations with batch support. |
-| Service | `AzBlobStorageBase` | Abstract base implementing `IAzBlobStorageBase`. Supports block blobs, page blobs, and append blobs. |
-| Service | `AzQueueStorageBase` | Abstract base implementing `IAzQueueStorageBase`. Handles Base64 message encoding and JSON serialization. |
-| Service | `AzTableStorageBase` | Abstract base implementing `IAzTableStorageBase`. Supports batch upsert, delete, and query with parallel partition processing. |
-| Extension | `LocalExtensions` | Extension methods for Table Storage key validation (`IsKeyValid`), `TableServiceClient.ExistsAsync`, and date-from-filename parsing. |
-| Message | `AzTableStorageArgs` | Event args for `BatchCompletedEvent`, carrying batch metadata (table name, partition key, count, remaining). |
+| Interface | [`IAzBlobStorageBase`](Abstractions/IAzBlobStorageBase.cs) | Contract for Azure Blob Storage container operations (upload, download, list, delete). |
+| Interface | [`IAzQueueStorageBase`](Abstractions/IAzQueueStorageBase.cs) | Contract for Azure Queue Storage operations (enqueue, dequeue). |
+| Interface | [`IAzTableStorageBase`](Abstractions/IAzTableStorageBase.cs) | Contract for Azure Table Storage CRUD operations with batch support. |
+| Service | [`AzBlobStorageBase`](Services/Base/AzBlobStorageBase.cs) | Abstract base implementing `IAzBlobStorageBase`. Supports block blobs and append blobs. |
+| Service | [`AzQueueStorageBase`](Services/Base/AzQueueStorageBase.cs) | Abstract base implementing `IAzQueueStorageBase`. Handles Base64 message encoding and JSON serialization. |
+| Service | [`AzTableStorageBase`](Services/Base/AzTableStorageBase.cs) | Abstract base implementing `IAzTableStorageBase`. Supports batch upsert, delete, and query with parallel partition processing. |
+| Extension | [`StorageExtensions`](Extensions/StorageExtensions.cs) | Extension methods for Table Storage key validation (`IsKeyValid`), `TableServiceClient.ExistsAsync`, and date-from-filename parsing. |
+| Message | [`AzTableStorageArgs`](Messages/AzTableStorageArgs.cs) | Event args for `BatchCompletedEvent`, carrying batch metadata (table name, partition key, count, remaining). |
 
-### Key Methods — `AzBlobStorageBase`
+### Key Methods — [`AzBlobStorageBase`](Services/Base/AzBlobStorageBase.cs)
 
 - `CreateContainerIfNotExists(CancellationToken)` — Creates the blob container if it does not exist.
 - `DownloadBlobAsync(string blobName, CancellationToken)` — Downloads blob content as a byte array.
 - `ListContainerBlobs(string? prefix, CancellationToken)` — Lists blobs in the container.
 - `GetBlobPrefixes(string? prefix, CancellationToken)` — Retrieves virtual directory prefixes.
 - `DeleteBlob(string blobName, CancellationToken)` — Deletes a blob.
-- `PageBlobTest(string path, CancellationToken)` — Page blob creation and write test.
+- `UploadBlob(string blobName, byte[] | Stream, CancellationToken)` — Uploads blob content.
 
-### Key Methods — `AzQueueStorageBase`
+### Key Methods — [`AzQueueStorageBase`](Services/Base/AzQueueStorageBase.cs)
 
 - `Enqueue<T>(T obj)` / `Enqueue<T>(List<T> objs)` — Serializes and enqueues messages.
 - `DequeueSingle<T>()` — Dequeues and deserializes a single message.
 - `DequeueMany<T>(int limit)` — Dequeues and deserializes multiple messages.
 
-### Key Methods — `AzTableStorageBase`
+### Key Methods — [`AzTableStorageBase`](Services/Base/AzTableStorageBase.cs)
 
 - `GetTables(CancellationToken)` — Lists all tables in the storage account.
 - `GetTableClient(string tableName, bool CreateIfNotExists, CancellationToken)` — Gets a `TableClient` for a table.
-- `UploadData<T>(TableClient, List<T>, bool useParallelism, CancellationToken)` — Batch upsert entities.
+- `UploadData<T>(TableClient, List<T>, bool useParallelism, CancellationToken)` — Batch upsert entities (thread-safe via `ConcurrentBag<T>`).
 - `UpsertEntity<T>(string tableName, T entity, CancellationToken)` — Upserts a single entity.
 - `DeleteData<T>(TableClient, List<T>, CancellationToken)` — Batch delete entities.
 - `GetEntities<T>(TableClient, ...)` — Queries entities with optional filtering and paging.
@@ -71,12 +71,13 @@ classDiagram
 
     class AzBlobStorageBase {
         <<abstract>>
-        #BlobServiceClient Client
+        #BlobContainerClient _containerClient
         #ILogger Logger
         +CreateContainerIfNotExists() Task
         +DownloadBlobAsync(name) Task~byte[]~
         +UploadBlob(name, data) Task
-        +PageBlobTest(path) Task
+        +ListContainerBlobs(prefix) Task~List~BlobItem~~
+        +GetBlobPrefixes(prefix) Task~List~string~~
     }
 
     class IAzQueueStorageBase {
@@ -88,10 +89,10 @@ classDiagram
 
     class AzQueueStorageBase {
         <<abstract>>
-        #QueueServiceClient Client
+        #QueueClient _queueClient
         #ILogger Logger
-        +Enqueue~T~(obj) Task
-        +Enqueue~T~(objs) Task
+        +Enqueue~T~(obj) Task~bool~
+        +Enqueue~T~(objs) Task~bool~
         +DequeueSingle~T~() Task~T~
         +DequeueMany~T~(limit) Task~List~T~~
     }
@@ -105,14 +106,14 @@ classDiagram
 
     class AzTableStorageBase {
         <<abstract>>
-        #TableServiceClient Client
+        #TableServiceClient _tableSvcClient
         #ILogger Logger
         +event BatchCompletedEvent
         +GetTables() AsyncPageable~TableItem~
         +UploadData~T~(client, entities, parallel) Task
         +UpsertEntity~T~(table, entity) Task
         +DeleteData~T~(client, entities) Task
-        +GetEntities~T~(client, filter) AsyncPageable~T~
+        +GetEntities~T~(client, filter) Task~List~T~~
     }
 
     class YourBlobService {
@@ -130,21 +131,39 @@ classDiagram
         +QueryEntities(filter) Task~List~
     }
 
-    AzBlobStorageBase ..> BlobServiceClient : uses
-    AzQueueStorageBase ..> QueueServiceClient : uses
+    AzBlobStorageBase ..> BlobContainerClient : uses
+    AzQueueStorageBase ..> QueueClient : uses
     AzTableStorageBase ..> TableServiceClient : uses
 ```
 
 **Usage Pattern:**
 
-1. Inherit from appropriate abstract base class
-2. Pass connection string or `TokenCredential` to base constructor
-3. Use protected `Client` and `Logger` fields
+1. Inherit from the appropriate abstract base class
+2. Pass connection string or `TokenCredential` (and optional `ServiceVersion`) to base constructor
+3. Use protected client and logger fields
 4. Call base methods or add domain-specific operations
 
 ## Configuration
 
-No configuration model. Services are constructed directly with connection strings or `TokenCredential`.
+No `IAppConfig` model — services are constructed directly via their base class constructors.
+
+All three base classes accept an optional `ServiceVersion?` parameter to pin the Azure Storage API version (useful for compatibility with [Azurite](https://github.com/Azure/Azurite) or older service endpoints):
+
+```csharp
+// Pin to a specific Blob API version (e.g. for Azurite compatibility)
+public class MyBlobService(string connectionString, string containerName)
+    : AzBlobStorageBase(connectionString, containerName, BlobClientOptions.ServiceVersion.V2024_11_04)
+{
+}
+
+// Use SDK-default (latest) version — omit or pass null
+public class MyTableService(string connectionString)
+    : AzTableStorageBase(connectionString)
+{
+}
+```
+
+When `null` (the default), each SDK uses its built-in latest `ServiceVersion`.
 
 ## Dependencies
 

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
@@ -11,23 +11,29 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     public string ContainerName { get; private set; }
 
     /// <summary>Initializes a new instance of <see cref="AzBlobStorageBase" /> using a connection string.</summary>
-    protected AzBlobStorageBase(string connectionString, string containerName)
+    protected AzBlobStorageBase(string connectionString, string containerName, BlobClientOptions.ServiceVersion? serviceVersion = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
         ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
         ContainerName = containerName;
-        _containerClient = new BlobContainerClient(connectionString, containerName);
+        var options = serviceVersion.HasValue ? new BlobClientOptions(serviceVersion.Value) : null;
+        _containerClient = options is not null
+            ? new BlobContainerClient(connectionString, containerName, options)
+            : new BlobContainerClient(connectionString, containerName);
         _containerClient.CreateIfNotExists();
     }
 
     /// <summary>Initializes a new instance of <see cref="AzBlobStorageBase" /> using a URI and token credential.</summary>
-    protected AzBlobStorageBase(Uri blobContainerUri, string containerName, TokenCredential credential)
+    protected AzBlobStorageBase(Uri blobContainerUri, string containerName, TokenCredential credential, BlobClientOptions.ServiceVersion? serviceVersion = null)
     {
         ArgumentNullException.ThrowIfNull(blobContainerUri);
         ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
         ContainerName = containerName;
         ArgumentNullException.ThrowIfNull(credential);
-        _containerClient = new BlobContainerClient(new Uri(blobContainerUri, containerName), credential);
+        var options = serviceVersion.HasValue ? new BlobClientOptions(serviceVersion.Value) : null;
+        _containerClient = options is not null
+            ? new BlobContainerClient(new Uri(blobContainerUri, containerName), credential, options)
+            : new BlobContainerClient(new Uri(blobContainerUri, containerName), credential);
         _containerClient.CreateIfNotExists();
     }
 

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
@@ -38,62 +38,10 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     }
 
     /// <inheritdoc/>
-    /// <remarks>See <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-dotnet" /> and <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-pageblob-overview?tabs=dotnet" />.</remarks>
-    public async Task PageBlobTest(string path, CancellationToken cancellationToken = default)
-    {
-        //https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs?WT.mc_id=AZ-MVP-5003203
-
-        //First, get a reference to a container. To create a page blob, call the GetPageBlobClient method, and then call the PageBlobClient.Create method.
-        //Pass in the max size for the blob to create. That size must be a multiple of 512 bytes.
-
-        long OneGigabyteAsBytes = 1024 * 1024 * 1024;
-
-        //BlobServiceClient blobServiceClient = new BlobServiceClient(_connectionString);
-        //var blobContainerClient = blobServiceClient.GetBlobContainerClient(_containerName);
-        //var pageBlobClient = blobContainerClient.GetPageBlobClient("0s4.vhd");
-        //pageBlobClient.Create(16 * OneGigabyteAsBytes);
-
-        var pageBlobClient = _containerClient.GetPageBlobClient("test.bin");
-        await pageBlobClient.CreateAsync(1 * OneGigabyteAsBytes, cancellationToken: cancellationToken);
-
-        //Resizing a page blob
-        //pageBlobClient.Resize(32 * OneGigabyteAsBytes, cancellationToken: cancellationToken);
-
-        //Writing pages to a page blob
-        //var array = new byte[512];
-
-        var bytes = await File.ReadAllBytesAsync(path, cancellationToken);//200kb
-
-        if (bytes.Length > 4 * 1024 * 1024)
-            throw new GenericException("bigger than 4mb");
-
-        using (var stream = new MemoryStream(bytes))
-        {
-            _ = await pageBlobClient.UploadPagesAsync(stream, 0, cancellationToken: cancellationToken);
-            //Debugger.Break();
-            //await blockBlob.UploadFromStreamAsync(stream);
-        }
-
-        IEnumerable<HttpRange> pageRanges = (await pageBlobClient.GetPageRangesAsync(cancellationToken: cancellationToken)).Value.PageRanges;
-        foreach (var range in pageRanges)
-        {
-            _ = await pageBlobClient.DownloadAsync(range, cancellationToken: cancellationToken);
-        }
-
-        _ = await pageBlobClient.DownloadAsync(new HttpRange(0, 1000), cancellationToken: cancellationToken);
-        //Debugger.Break();
-    }
-
-    /// <inheritdoc/>
     public async Task<bool> CreateContainerIfNotExists(CancellationToken cancellationToken)
     {
-        if (!await _containerClient.ExistsAsync(cancellationToken))
-        {
-            _ = await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
-            return true;
-        }
-        else
-            return false;
+        var response = await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        return response is not null;
     }
 
     /// <inheritdoc/>
@@ -103,7 +51,6 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     /// <inheritdoc/>
     public async Task<byte[]?> DownloadBlobAsync(string blobName, CancellationToken cancellationToken = default)
     {
-        byte[] bytes;
         var blobClient = _containerClient.GetBlobClient(blobName);
 
         if (!await blobClient.ExistsAsync(cancellationToken))
@@ -111,31 +58,17 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
             _logger.LogWarning("{ClassName} blob {BlobName} does not exist", nameof(AzBlobStorageBase), blobName);
             return null;
         }
-        var downloadInfo = await blobClient.DownloadAsync(cancellationToken);
-        using (var ms = new MemoryStream())
-        {
-            await downloadInfo.Value.Content.CopyToAsync(ms, cancellationToken);
-            bytes = ms.ToArray();
-        }
-        return bytes;
+        var response = await blobClient.DownloadContentAsync(cancellationToken);
+        return response.Value.Content.ToArray();
     }
 
     /// <inheritdoc/>
     public async Task<List<BlobItem>> ListContainerBlobs(string? prefix = null, CancellationToken cancellationToken = default)
     {
-        var l = new List<BlobItem>();
+        var blobs = new List<BlobItem>();
         await foreach (var blobItem in _containerClient.GetBlobsAsync(new GetBlobsOptions { Prefix = prefix }, cancellationToken: cancellationToken))
-            l.Add(blobItem);
-        return l;
-    }
-
-    /// <summary>Lists all blobs in the container, optionally filtered by <paramref name="prefix"/>.</summary>
-    public async Task<List<BlobItem>> ListBlobs(string? prefix = null, CancellationToken cancellationToken = default)
-    {
-        var l = new List<BlobItem>();
-        await foreach (var blobItem in _containerClient.GetBlobsAsync(new GetBlobsOptions { Prefix = prefix }, cancellationToken: cancellationToken))
-            l.Add(blobItem);
-        return l;
+            blobs.Add(blobItem);
+        return blobs;
     }
 
     /// <inheritdoc/>
@@ -145,7 +78,7 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
         await foreach (var hierarchyItem in _containerClient.GetBlobsByHierarchyAsync(new GetBlobsByHierarchyOptions { Prefix = prefix, Delimiter = "/" }, cancellationToken: cancellationToken))
             hs.Add(hierarchyItem.Prefix);
         var prefixes = hs.Select(p => p.Replace("/", string.Empty)).ToList();
-        _logger.LogInformation("{ClassName} Symbols/prefixes returned from blob storage are; {Symbols}",
+        _logger.LogDebug("{ClassName} prefixes returned from blob storage are; {Prefixes}",
             nameof(AzBlobStorageBase), prefixes);
         return prefixes;
     }
@@ -153,15 +86,15 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     /// <inheritdoc/>
     public async Task UploadBlob(string blobName, byte[] bytes, CancellationToken cancellationToken)
     {
-        var _blobClient = _containerClient.GetBlobClient(blobName);
+        var blobClient = _containerClient.GetBlobClient(blobName);
         using var stream = new MemoryStream(bytes, writable: false);
-        _ = await _blobClient.UploadAsync(stream, true, cancellationToken);
+        _ = await blobClient.UploadAsync(stream, true, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task UploadBlob(string blobName, Stream stream, CancellationToken cancellationToken)
     {
-        var _blobClient = _containerClient.GetBlobClient(blobName);
-        _ = await _blobClient.UploadAsync(stream, true, cancellationToken);
+        var blobClient = _containerClient.GetBlobClient(blobName);
+        _ = await blobClient.UploadAsync(stream, true, cancellationToken);
     }
 }

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
@@ -10,24 +10,28 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     private readonly QueueClient _queueClient;
 
     /// <summary>Initializes a new instance of <see cref="AzQueueStorageBase"/> using a connection string.</summary>
-    protected AzQueueStorageBase(string connectionString, string queueName)
+    protected AzQueueStorageBase(string connectionString, string queueName, QueueClientOptions.ServiceVersion? serviceVersion = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
         ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
-        _queueClient = new QueueClient(connectionString, queueName,
-            //https://github.com/Azure/azure-sdk-for-net/issues/10242
-            new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 });
+        //https://github.com/Azure/azure-sdk-for-net/issues/10242
+        var options = serviceVersion.HasValue
+            ? new QueueClientOptions(serviceVersion.Value) { MessageEncoding = QueueMessageEncoding.Base64 }
+            : new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 };
+        _queueClient = new QueueClient(connectionString, queueName, options);
     }
 
     /// <summary>Initializes a new instance of <see cref="AzQueueStorageBase"/> using a <see cref="TokenCredential"/>.</summary>
-    protected AzQueueStorageBase(Uri queueUri, string queueName, TokenCredential credential)
+    protected AzQueueStorageBase(Uri queueUri, string queueName, TokenCredential credential, QueueClientOptions.ServiceVersion? serviceVersion = null)
     {
         ArgumentNullException.ThrowIfNull(queueUri);
         ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
         ArgumentNullException.ThrowIfNull(credential);
-        _queueClient = new QueueClient(new Uri(queueUri, queueName), credential,
-            //https://github.com/Azure/azure-sdk-for-net/issues/10242
-            new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 });
+        //https://github.com/Azure/azure-sdk-for-net/issues/10242
+        var options = serviceVersion.HasValue
+            ? new QueueClientOptions(serviceVersion.Value) { MessageEncoding = QueueMessageEncoding.Base64 }
+            : new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 };
+        _queueClient = new QueueClient(new Uri(queueUri, queueName), credential, options);
     }
 
     private bool _haveCheckedIfQueueExists = false;

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
@@ -34,13 +34,15 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
         _queueClient = new QueueClient(new Uri(queueUri, queueName), credential, options);
     }
 
-    private bool _haveCheckedIfQueueExists = false;
+    private int _queueExistsChecked;
 
     private async ValueTask CreateQueueIfNotExistsAsync(CancellationToken cancellationToken = default)
     {
-        if (!_haveCheckedIfQueueExists && (await _queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken) is not null))
-            _logger.LogDebug("{ClassName} storage queue didn't exist so have now created {QueueName}", nameof(AzQueueStorageBase), _queueClient.Name);
-        _haveCheckedIfQueueExists = true;
+        if (Interlocked.CompareExchange(ref _queueExistsChecked, 1, 0) == 0)
+        {
+            if (await _queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken) is not null)
+                _logger.LogDebug("{ClassName} storage queue didn't exist so have now created {QueueName}", nameof(AzQueueStorageBase), _queueClient.Name);
+        }
     }
 
     /// <inheritdoc/>
@@ -50,7 +52,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     public async Task<bool> Enqueue<T>(List<T> objs, CancellationToken cancellationToken = default) where T : class
     {
         await CreateQueueIfNotExistsAsync(cancellationToken);
-        var i = 1;
+        var successCount = 0;
         foreach (var obj in objs)
         {
             if (obj is null)
@@ -67,49 +69,47 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{ClassName} failed to insert {MessageType} into storage queue '{QueueName}' JSON content is '{Bytes}' bytes",
+                _logger.LogError(ex, "{ClassName} failed to insert {MessageType} into storage queue {QueueName}, JSON content is {ByteCount} bytes",
                     nameof(AzQueueStorageBase), typeof(T).Name, _queueClient.Name, message.ToArray().Length);
             }
             if (result is not null && result.Value is not null)
             {
-                _logger.LogDebug("{ClassName} {MessageType} {Iteration} of {MessageCount} inserted into storage queue '{QueueName}', MessageId={MessageId}",
-                    nameof(AzQueueStorageBase), typeof(T).Name, i, objs.Count, _queueClient.Name, result.Value.MessageId);
-                i++;
+                successCount++;
+                _logger.LogDebug("{ClassName} {MessageType} {Iteration} of {MessageCount} inserted into storage queue {QueueName}, MessageId={MessageId}",
+                    nameof(AzQueueStorageBase), typeof(T).Name, successCount, objs.Count, _queueClient.Name, result.Value.MessageId);
             }
         }
-        return i > 0;
+        return successCount > 0;
     }
 
     /// <inheritdoc/>
     public async Task<(T?, QueueMessage)> DequeueSingle<T>(CancellationToken cancellationToken = default) where T : class
     {
-        //_logger.LogTrace("{ClassName} trying account {AccountName}...", nameof(AzQueueStorageBase), _queueClient.AccountName);
         await CreateQueueIfNotExistsAsync(cancellationToken);
-        // Get the next message
         var retrievedMessage = await _queueClient.ReceiveMessageAsync(cancellationToken: cancellationToken);
         if (retrievedMessage is not null && retrievedMessage.Value is not null)
         {
             var json = retrievedMessage.Value.Body.ToString();
             T? obj = null;
-            var IsCorrupted = false;
+            var isCorrupted = false;
             try
             {
                 obj = json.FromJson<T>();
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{ClassName} failed to deserialize JSON, '{Json}'", nameof(AzQueueStorageBase), json);
-                IsCorrupted = true;
+                _logger.LogError(ex, "{ClassName} failed to deserialize JSON, {Json}", nameof(AzQueueStorageBase), json);
+                isCorrupted = true;
             }
             finally
             {
                 _ = await _queueClient.DeleteMessageAsync(retrievedMessage.Value.MessageId, retrievedMessage.Value.PopReceipt, cancellationToken);
-                if (IsCorrupted)
-                    _logger.LogWarning("{ClassName} removed message id {Id} from queue as it failed deserialization, '{Json}'",
-                        nameof(AzQueueStorageBase), retrievedMessage.Value.MessageId, json);
+                if (isCorrupted)
+                    _logger.LogWarning("{ClassName} removed corrupted message {MessageId} from queue {QueueName}",
+                        nameof(AzQueueStorageBase), retrievedMessage.Value.MessageId, _queueClient.Name);
                 else
-                    _logger.LogInformation("{ClassName} removed message id {Id} from queue as it passed deserialization!",
-                        nameof(AzQueueStorageBase), retrievedMessage.Value.MessageId);
+                    _logger.LogDebug("{ClassName} dequeued message {MessageId} from queue {QueueName}",
+                        nameof(AzQueueStorageBase), retrievedMessage.Value.MessageId, _queueClient.Name);
             }
             return (obj, retrievedMessage.Value);
         }
@@ -137,11 +137,11 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     private async Task<List<QueueMessage>> Dequeue(int limit = 1, CancellationToken cancellationToken = default)
     {
         var properties = await _queueClient.GetPropertiesAsync(cancellationToken);
-        if (properties.Value.ApproximateMessagesCount > 1) limit = properties.Value.ApproximateMessagesCount;
-        var l = new List<QueueMessage>(limit);
-        var messages = await _queueClient.ReceiveMessagesAsync(limit, cancellationToken: cancellationToken);
-        foreach (var retrievedMessage in messages.Value)
-            l.Add(retrievedMessage);
-        return l;
+        var available = properties.Value.ApproximateMessagesCount;
+        var maxMessages = Math.Min(limit, Math.Min(available, 32));
+        if (maxMessages <= 0)
+            return [];
+        var messages = await _queueClient.ReceiveMessagesAsync(maxMessages, cancellationToken: cancellationToken);
+        return [.. messages.Value];
     }
 }

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzTableStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzTableStorageBase.cs
@@ -51,7 +51,7 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <summary>Sets the active <see cref="TableClient"/> for <paramref name="tableName"/>, optionally creating it if it does not exist.</summary>
     protected async Task<TableClient> SetActiveTable(string tableName, bool CreateIfNotExists = true, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(tableName)) throw new ArgumentNullException(nameof(tableName), "expected!");
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
         var table = _tableSvcClient.GetTableClient(tableName);
         if (!await _tableSvcClient.ExistsAsync(table.Name) && CreateIfNotExists)
             await table.CreateIfNotExistsAsync(cancellationToken);
@@ -87,43 +87,42 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
 
     private async Task<List<T>> BatchOperation<T>(TableClient tbl, List<T> entities, bool useParallelism = true, bool InsertOrReplace = true, CancellationToken cancellationToken = default) where T : class, ITableEntity
     {
-        var partitions = entities.GroupBy(l => l.PartitionKey)
+        var partitions = entities.GroupBy(e => e.PartitionKey)
             .Select(g => new
             {
                 PartitionKey = g.Key,
-                Entities = g.Select(p => p).ToList()
+                Entities = g.ToList()
             }).ToList();
 
-        var retval = new List<T>(entities.Count);
-        //var batch = new List<TableTransactionAction>();
+        var retval = new ConcurrentBag<T>();
         var po = new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = useParallelism ? Environment.ProcessorCount : 1 };
         await Parallel.ForEachAsync(partitions, po, async (p, ct) =>
         {
             await RunBatches(p.PartitionKey, p.Entities, ct);
         });
 
-        return retval;
+        return retval.ToList();
 
-        async Task RunBatches(string _partitionKey, List<T> _entities, CancellationToken cancellationToken)
+        async Task RunBatches(string partitionKey, List<T> partitionEntities, CancellationToken cancellationToken)
         {
-            while (_entities.Count > 0)
+            while (partitionEntities.Count > 0)
             {
-                //count how many remaining records
-                var count = _entities.Count;
+                var count = partitionEntities.Count;
                 var batchSize = Math.Min(100, count);
-                var top100 = _entities.Take(batchSize).ToList();
-                var _retval = await ExecuteBatchOperation(top100, cancellationToken);
-                if (_retval.Count > 0)
+                var batch = partitionEntities.Take(batchSize).ToList();
+                var batchResult = await ExecuteBatchOperation(batch, cancellationToken);
+                if (batchResult.Count > 0)
                 {
-                    _entities.RemoveRange(0, batchSize);
-                    retval!.AddRange(_retval);
+                    partitionEntities.RemoveRange(0, batchSize);
+                    foreach (var item in batchResult)
+                        retval.Add(item);
                     _logger.LogDebug("{ClassName} account {StorageAccountName}, table {TableName}, partition {Partition}, (1 of {PartitionCount}), {EntityCount} entities handled, {RemainingCount} entities remaining",
-                        nameof(AzTableStorageBase), _tableSvcClient.AccountName, tbl.Name, _partitionKey, partitions.Count, _retval.Count, count - batchSize);
-                    OnRaiseBatchCompletedEvent(new AzTableStorageArgs(_tableSvcClient.AccountName, tbl.Name, _partitionKey, _retval.Count, count - batchSize));
+                        nameof(AzTableStorageBase), _tableSvcClient.AccountName, tbl.Name, partitionKey, partitions.Count, batchResult.Count, count - batchSize);
+                    OnRaiseBatchCompletedEvent(new AzTableStorageArgs(_tableSvcClient.AccountName, tbl.Name, partitionKey, batchResult.Count, count - batchSize));
                 }
                 else
                     _logger.LogWarning("{ClassName} table {TableName}, partition {Partition} no changes affected...",
-                        nameof(AzTableStorageBase), tbl.Name, _partitionKey);
+                        nameof(AzTableStorageBase), tbl.Name, partitionKey);
             }
         }
 
@@ -219,11 +218,10 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     }
 
     /// <inheritdoc/>
-    public static async Task<List<T>> GetEntities<T>(TableClient table, string partitionKey, string rowKeyFrom, CancellationToken cancellationToken) where T : class, ITableEntity, new()
+    public async Task<List<T>> GetEntities<T>(TableClient table, string partitionKey, string rowKeyFrom, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
         var filter = TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey} and RowKey lt {rowKeyFrom}");
-        var entities = await table.QueryAsync<T>(filter, cancellationToken: cancellationToken).ToListAsync(cancellationToken: cancellationToken);
-        return entities.ToList();
+        return await table.QueryAsync<T>(filter, cancellationToken: cancellationToken).ToListAsync(cancellationToken: cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -237,8 +235,7 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     public async Task<List<T>> GetEntities<T>(TableClient tbl, string partitionKey, string rowKeyFrom, string rowKeyTo, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
         var filter = TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey} and RowKey lt {rowKeyFrom} and RowKey ge {rowKeyTo}");
-        var entities = await tbl.QueryAsync<T>(filter, cancellationToken: cancellationToken).ToListAsync(cancellationToken: cancellationToken);
-        return entities.ToList();
+        return await tbl.QueryAsync<T>(filter, cancellationToken: cancellationToken).ToListAsync(cancellationToken: cancellationToken);
     }
     #endregion
 

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzTableStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzTableStorageBase.cs
@@ -17,18 +17,22 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     protected TableServiceClient _tableSvcClient { get; set; }
 
     /// <summary>Initializes a new instance of <see cref="AzTableStorageBase" /> using a connection string.</summary>
-    protected AzTableStorageBase(string connectionString)
+    protected AzTableStorageBase(string connectionString, TableClientOptions.ServiceVersion? serviceVersion = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
-        _tableSvcClient = new TableServiceClient(connectionString);
+        _tableSvcClient = serviceVersion.HasValue
+            ? new TableServiceClient(connectionString, new TableClientOptions(serviceVersion.Value))
+            : new TableServiceClient(connectionString);
     }
 
     /// <summary>Initializes a new instance of <see cref="AzTableStorageBase" /> using a service endpoint and token credential.</summary>
-    protected AzTableStorageBase(Uri endpoint, TokenCredential credential)
+    protected AzTableStorageBase(Uri endpoint, TokenCredential credential, TableClientOptions.ServiceVersion? serviceVersion = null)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentNullException.ThrowIfNull(credential);
-        _tableSvcClient = new TableServiceClient(endpoint, credential);
+        _tableSvcClient = serviceVersion.HasValue
+            ? new TableServiceClient(endpoint, credential, new TableClientOptions(serviceVersion.Value))
+            : new TableServiceClient(endpoint, credential);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary

Adds configurable `ServiceVersion` parameters to all three Azure Storage base classes and fixes several bugs and code quality issues discovered during review.

## ServiceVersion Configuration

All three base classes (`AzBlobStorageBase`, `AzTableStorageBase`, `AzQueueStorageBase`) now accept an optional `ServiceVersion?` parameter on both constructors. When `null` (default), the SDK's latest version is used. This enables pinning to an older API version for compatibility with Azurite or other emulators.

## Bug Fixes

| Class | Issue | Fix |
| --- | --- | --- |
| `AzTableStorageBase` | `BatchOperation` mutated `List<T>` from `Parallel.ForEachAsync` — not thread-safe | Replaced with `ConcurrentBag<T>` |
| `AzQueueStorageBase` | `Enqueue` counter started at 1, so `return i > 0` was always `true` | Counter starts at 0, returns `successCount > 0` |
| `AzQueueStorageBase` | `Dequeue` replaced caller's `limit` with `ApproximateMessagesCount` | Uses `Math.Min(limit, available, 32)` to respect both limit and API max |
| `AzQueueStorageBase` | `_haveCheckedIfQueueExists` bool with no synchronization — race condition on concurrent first calls | `Interlocked.CompareExchange` ensures single execution |

## Code Quality

- **Removed `PageBlobTest`** — exploratory/test code with hardcoded values, commented-out lines; removed from interface and class
- **Removed duplicate `ListBlobs`** — identical to `ListContainerBlobs`
- **Simplified `CreateContainerIfNotExists`** — removed redundant `ExistsAsync` before `CreateIfNotExistsAsync`
- **Replaced deprecated `DownloadAsync`** with `DownloadContentAsync`
- **Removed double `.ToList()`** in two `GetEntities` overloads
- **Made static `GetEntities<T>(TableClient, ...)` an instance method** — consistent with the rest of the class
- **`SetActiveTable`** uses `ArgumentException.ThrowIfNullOrWhiteSpace`
- **Downgraded noisy logs** — `GetBlobPrefixes` and `DequeueSingle` success path moved from Information to Debug
- **Fixed variable naming** — `_blobClient` → `blobClient`, `IsCorrupted` → `isCorrupted`
- **Removed quoted log template params** — `'{QueueName}'` → `{QueueName}`

## Breaking Changes

- `IAzBlobStorageBase.PageBlobTest` removed
- `AzBlobStorageBase.ListBlobs` removed (use `ListContainerBlobs`)
- `AzTableStorageBase.GetEntities<T>(TableClient, string, string, CancellationToken)` is no longer `static`
