### PR TITLE
perf: sealed classes, ConfigureAwait(false), GeneratedRegex, and Span optimizations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,26 +69,52 @@ Configured in `Directory.Build.props`: `IDE1006`, `IDE0079`, `IDE0042`, `CS0162`
 
 ### Performance
 
+#### ValueTask vs Task
+
+- **Use `ValueTask` / `ValueTask<T>`** when a method frequently completes synchronously — cache hits, `TryRead` on channels, dictionary lookups that short-circuit, or wrappers returning a pre-computed result. Avoids allocating a `Task` on the synchronous path.
+- **Use `Task` / `Task<T>`** when the method almost always goes async (HTTP, database, file I/O).
+- **Never cache, await twice, or concurrently await a `ValueTask`**. Call `.AsTask()` at the call site if needed.
+- **Hot-path interface signatures** (channel brokers, cache accessors) should prefer `ValueTask<T>` so implementations can avoid allocation when data is already available.
+
+#### sealed Classes
+
+- **Mark every concrete class `sealed`** unless it is explicitly designed for inheritance (has `virtual`/`abstract` members or is documented as a base class). The JIT devirtualises and inlines method calls on sealed types.
+- Background services, DI-registered services, entity types, converters, and middleware should default to `sealed`.
+- Removing `sealed` later is a non-breaking change.
+
+#### Frozen Collections
+
+- **`FrozenDictionary<TKey, TValue>` / `FrozenSet<T>`** for any collection populated once at startup and never mutated. Optimised for read throughput at the expense of creation cost.
+- Build via `.ToFrozenDictionary()` / `.ToFrozenSet()` at the end of the initialisation path. Store as the concrete `FrozenDictionary<,>` type (not `IReadOnlyDictionary<,>`) so the JIT can devirtualise lookups.
+
+#### ConfigureAwait(false) in Library Code
+
+- **Library projects** that do not touch `HttpContext` after an await must use `ConfigureAwait(false)` on every `await` to avoid unnecessary `SynchronizationContext` capture.
+- **Application entry-point projects** (workloads, controllers) may omit it — ASP.NET Core has no sync context by default.
+
 #### Span-Based Parsing
 
-- **`ReadOnlySpan<byte>` for raw byte streams**: When data arrives as UTF-8 bytes (`PipeReader`, Redis buffers, network streams), parse directly from `ReadOnlySpan<byte>` — do not materialise a `string` first. This avoids allocation and encoding conversion on the hot path.
-- **`ReadOnlySpan<char>` for API convenience only**: The `ReadOnlySpan<char>` overload of a parsing method exists so callers who already hold a span (e.g. from `string.AsSpan()` slicing) do not need to call `.ToString()`. It does **not** offer meaningful speed improvement over the `string` overload for already-materialised strings — the loop logic is identical.
-- **Extension method deduplication**: When providing both `string` and `ReadOnlySpan<char>` overloads, the span version holds the implementation and the string version is a thin wrapper delegating via `.AsSpan()`:
+- **`ReadOnlySpan<byte>` for raw byte streams**: Parse directly from `ReadOnlySpan<byte>` when data arrives as UTF-8 bytes (`PipeReader`, Redis buffers, network streams) — do not materialise a `string` first.
+- **`ReadOnlySpan<char>` for API convenience**: Exists so callers holding a span do not need `.ToString()`. No speed benefit over the `string` overload for already-materialised strings.
+- **Extension method deduplication**: The span version holds the implementation; the string version delegates via `.AsSpan()`.
 
-```csharp
-public static int Decimal2Int(this string input, int exp = 0)
-    => input.AsSpan().Decimal2Int(exp);
-```
+#### SearchValues\<T\>
+
+- **`SearchValues<char>` / `SearchValues<byte>`** (static field) for repeated `IndexOfAny` / `ContainsAny` on a fixed set of delimiters or sentinels. The runtime selects the optimal vectorised implementation at startup.
+
+#### System.Threading.Lock
+
+- Prefer `System.Threading.Lock` over `object` for dedicated lock instances. Enables a thinner locking path and signals intent more clearly.
 
 #### Hot-Path Conventions
 
-- **`[MethodImpl(MethodImplOptions.AggressiveInlining)]`**: Apply to leaf-level parsing and conversion methods called in tight loops (e.g. `Decimal2Int`, `Decimal2Long`, `TryReadLine`). Do not apply to methods with complex control flow or large method bodies — the JIT already inlines small methods and forcing it on large ones hurts instruction-cache performance.
-- **Avoid allocations in tight loops**: In `Channel` readers, `PipeReader` loops, stream consumers, and tick processors:
+- **`[MethodImpl(MethodImplOptions.AggressiveInlining)]`**: Apply to leaf-level parsing/conversion methods called in tight loops. Do not apply to methods with complex control flow — the JIT already inlines small methods.
+- **Avoid allocations in tight loops** (`Channel` readers, `PipeReader` loops, stream consumers):
   - Use `stackalloc` or `ArrayPool<T>` for temporary buffers instead of `new byte[]`.
   - Prefer `ReadOnlySequence<byte>` slicing over `.ToArray()`.
   - Use source-generated `[LoggerMessage]` to eliminate `params object[]` boxing (see Logging section).
-- **Async pass-through on wrappers**: Dropping `async`/`await` on thin single-call wrappers avoids state-machine allocation (see Style section for the full convention).
-- **`PipeReader` for line-oriented binary streams**: When reading line-delimited data (CSV tick files, Redis bulk replies), use `PipeReader` with `TryReadLine` to process data in-place from the pipe's buffer without copying to intermediate `string` objects.
+- **Async pass-through on wrappers**: Drop `async`/`await` on thin single-call wrappers to avoid state-machine allocation (see Style section).
+- **`PipeReader` for line-oriented binary streams**: Process data in-place from the pipe's buffer without copying to intermediate `string` objects.
 
 ### Controllers / Web API
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.7" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.7" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.7" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.7" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.7" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.7" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.8" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.8" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.8" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.8" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.8" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.8" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.50.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,15 +14,15 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.6" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.6" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.6" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.6" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.6" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.6" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.7" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.7" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.7" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.7" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.7" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.7" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.50.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/src/CasCap.Api.Azure.CognitiveServices/Services/SpeechService.cs
+++ b/src/CasCap.Api.Azure.CognitiveServices/Services/SpeechService.cs
@@ -32,7 +32,7 @@ public sealed class SpeechService : ISpeechService
     {
         using var fileOutput = AudioConfig.FromWavFileOutput(path);
         using var synthesizer = new SpeechSynthesizer(_speechConfig, fileOutput);
-        using var result = await synthesizer.SpeakTextAsync(soundByte);
+        using var result = await synthesizer.SpeakTextAsync(soundByte).ConfigureAwait(false);
         if (result.Reason == ResultReason.SynthesizingAudioCompleted)
             _logger.LogDebug("{ClassName} Speech synthesized to speaker for text {Soundbyte}", nameof(SpeechService), soundByte);
         else if (result.Reason == ResultReason.Canceled)
@@ -52,7 +52,7 @@ public sealed class SpeechService : ISpeechService
     {
         using var audioInput = AudioConfig.FromWavFileInput(path);
         using var recognizer = new SpeechRecognizer(_speechConfig, audioInput);
-        var result = await recognizer.RecognizeOnceAsync();
+        var result = await recognizer.RecognizeOnceAsync().ConfigureAwait(false);
         return HandleRecognitionResult(result);
     }
 
@@ -60,7 +60,7 @@ public sealed class SpeechService : ISpeechService
     public async Task<string?> RecognizeFromMicrophone()
     {
         using var recognizer = new SpeechRecognizer(_speechConfig);
-        var result = await recognizer.RecognizeOnceAsync();
+        var result = await recognizer.RecognizeOnceAsync().ConfigureAwait(false);
         return HandleRecognitionResult(result);
     }
 

--- a/src/CasCap.Api.Azure.CognitiveServices/Services/SpeechService.cs
+++ b/src/CasCap.Api.Azure.CognitiveServices/Services/SpeechService.cs
@@ -1,7 +1,7 @@
 namespace CasCap.Services;
 
 /// <inheritdoc/>
-public class SpeechService : ISpeechService
+public sealed class SpeechService : ISpeechService
 {
     private static readonly ILogger _logger = ApplicationLogging.CreateLogger(nameof(SpeechService));
 

--- a/src/CasCap.Api.Azure.ContainerRegistry/Services/AcrServiceBase.cs
+++ b/src/CasCap.Api.Azure.ContainerRegistry/Services/AcrServiceBase.cs
@@ -26,14 +26,14 @@ public abstract class AcrServiceBase
     {
         // Perform an operation
         AsyncPageable<string> repositories = _client.GetRepositoryNamesAsync();
-        await foreach (var repositoryName in repositories)
+        await foreach (var repositoryName in repositories.ConfigureAwait(false))
         {
             _logger.LogInformation("{ClassName} starting {RepositoryName}", nameof(AcrServiceBase), repositoryName);
 
             var repo = _client.GetRepository(repositoryName);
 
             var manifests = repo.GetAllManifestPropertiesAsync(ArtifactManifestOrder.LastUpdatedOnDescending);
-            await foreach (var manifest in manifests)
+            await foreach (var manifest in manifests.ConfigureAwait(false))
             {
                 _logger.LogInformation("{ClassName} {RepositoryName} tags={Tags}", nameof(AcrServiceBase), manifest.RepositoryName, manifest.Tags);
             }

--- a/src/CasCap.Api.Azure.EventHub/Services/PublisherService.cs
+++ b/src/CasCap.Api.Azure.EventHub/Services/PublisherService.cs
@@ -45,13 +45,13 @@ public abstract class PublisherService<T> : IPublisherService<T>// where T : IEv
         var l = new List<byte[]>(objs.Count);
         foreach (var obj in objs)
             l.Add(obj.ToMessagePack());
-        await Push(l);
+        await Push(l).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task Push(List<byte[]> bytesCollection)
     {
-        using var eventBatch = await _producerClient.CreateBatchAsync();
+        using var eventBatch = await _producerClient.CreateBatchAsync().ConfigureAwait(false);
         try
         {
             foreach (var bytes in bytesCollection)
@@ -60,7 +60,7 @@ public abstract class PublisherService<T> : IPublisherService<T>// where T : IEv
                 if (!eventBatch.TryAdd(data))
                     throw new GenericException($"EventHubName={typeof(T).Name}, batch size too big!");
             }
-            await _producerClient.SendAsync(eventBatch);
+            await _producerClient.SendAsync(eventBatch).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -76,7 +76,7 @@ public abstract class PublisherService<T> : IPublisherService<T>// where T : IEv
         {
             var message = $"Message {i}";
             //_logger.LogDebug("{ClassName} Sending message: {Message}", nameof(PublisherService<T>), message);
-            await Push(Encoding.UTF8.GetBytes(message));
+            await Push(Encoding.UTF8.GetBytes(message)).ConfigureAwait(false);
         }
         _logger.LogDebug("{ClassName} {NumMessagesToSend} messages sent.", nameof(PublisherService<T>), numMessagesToSend);
     }

--- a/src/CasCap.Api.Azure.EventHub/Services/SubscriberService.cs
+++ b/src/CasCap.Api.Azure.EventHub/Services/SubscriberService.cs
@@ -63,14 +63,14 @@ public abstract class SubscriberService<T> : ISubscriberService<T>
     {
         try
         {
-            await _checkpointStore.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            await _checkpointStore.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             _eventProcessorClient.ProcessEventAsync += ProcessEventHandler;
             _eventProcessorClient.ProcessErrorAsync += ProcessErrorHandler;
             try
             {
                 _logger.LogDebug("{ClassName} _eventProcessorClient.StartProcessingAsync... for {EventHubName}", nameof(SubscriberService<T>), _eventProcessorClient.EventHubName);
-                await _eventProcessorClient.StartProcessingAsync(cancellationToken);
-                await Task.Delay(Timeout.Infinite, cancellationToken);
+                await _eventProcessorClient.StartProcessingAsync(cancellationToken).ConfigureAwait(false);
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -79,7 +79,7 @@ public abstract class SubscriberService<T> : ISubscriberService<T>
             finally
             {
                 // This may take up to the length of time defined as part of the configured TryTimeout of the processor; by default, this is 60 seconds.
-                await _eventProcessorClient.StopProcessingAsync(cancellationToken);
+                await _eventProcessorClient.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
             }
         }
         catch
@@ -132,7 +132,7 @@ public abstract class SubscriberService<T> : ISubscriberService<T>
 
             if (eventsSinceLastCheckpoint >= 50)
             {
-                await args.UpdateCheckpointAsync();
+                await args.UpdateCheckpointAsync().ConfigureAwait(false);
                 partitionEventCount[partitionId] = 0;
             }
         }

--- a/src/CasCap.Api.Azure.LogAnalytics/Services/QueryService.cs
+++ b/src/CasCap.Api.Azure.LogAnalytics/Services/QueryService.cs
@@ -23,7 +23,7 @@ public sealed class QueryService(
         //var query = "availabilityResults | summarize count() by name, bin(duration,500) | order by _count desc";
         //var metric = "availabilityResults/duration";
 
-        var queryResults = await client.QueryWorkspaceAsync(logAnalyticsConfig.Value.WorkspaceId, query, timeRange);
+        var queryResults = await client.QueryWorkspaceAsync(logAnalyticsConfig.Value.WorkspaceId, query, timeRange).ConfigureAwait(false);
         //var queryResults = await client.Query.ExecuteAsync(_appInsightsOptions.ApiApplicationId, query, timespan);
         foreach (var row in queryResults.Value.Table.Rows)
         {
@@ -49,7 +49,7 @@ public sealed class QueryService(
     public async Task<List<AppInsightsObject>> GetExceptions(int limit = 50)
     {
         var query = $"exceptions | limit {limit} | order by timestamp";
-        var queryResults = await client.QueryWorkspaceAsync(logAnalyticsConfig.Value.WorkspaceId, query, new QueryTimeRange(TimeSpan.FromDays(1)));
+        var queryResults = await client.QueryWorkspaceAsync(logAnalyticsConfig.Value.WorkspaceId, query, new QueryTimeRange(TimeSpan.FromDays(1))).ConfigureAwait(false);
         var l = new List<AppInsightsObject>(queryResults.Value.Table.Rows.Count);
         foreach (var e in queryResults.Value.Table.Rows)
         {

--- a/src/CasCap.Api.Azure.LogAnalytics/Services/QueryService.cs
+++ b/src/CasCap.Api.Azure.LogAnalytics/Services/QueryService.cs
@@ -6,7 +6,7 @@ namespace CasCap.Services;
 /// <see href="https://zimmergren.net/retrieve-logs-from-application-insights-programmatically-with-net-core-c/" />,
 /// and <see href="https://learn.microsoft.com/en-us/dotnet/api/overview/azure/monitor.query-readme?view=azure-dotnet" />.
 /// </remarks>
-public class QueryService(
+public sealed class QueryService(
     ILogger<QueryService> logger,
     IOptions<LogAnalyticsConfig> logAnalyticsConfig,
     TokenCredential credential) : IQueryService

--- a/src/CasCap.Api.Azure.ServiceBus/Services/Base/ServiceBase.cs
+++ b/src/CasCap.Api.Azure.ServiceBus/Services/Base/ServiceBase.cs
@@ -26,7 +26,7 @@ public abstract class ServiceBase(ILogger<ServiceBase> logger)
         var messageBody = args.Message.Body.ToString();
         _logger.LogInformation("{ClassName} Received: {MessageBody}", nameof(ServiceBase), messageBody);
         OnRaiseMessageReceivedEvent(args);
-        await args.CompleteMessageAsync(args.Message);
+        await args.CompleteMessageAsync(args.Message).ConfigureAwait(false);
     }
 
     /// <summary>Handles a processing error by logging the exception and raising <see cref="ErrorReceivedEvent"/>.</summary>

--- a/src/CasCap.Api.Azure.ServiceBus/Services/QueueService.cs
+++ b/src/CasCap.Api.Azure.ServiceBus/Services/QueueService.cs
@@ -34,7 +34,7 @@ public sealed class QueueService : ServiceBase, IQueueService
         var sender = client.CreateSender(_queueName);
 
         // send the message
-        await sender.SendMessageAsync(message);
+        await sender.SendMessageAsync(message).ConfigureAwait(false);
         _logger.LogInformation("{ClassName} Sent a single message to the queue: {QueueName}",
             nameof(QueueService), _queueName);
     }
@@ -52,7 +52,7 @@ public sealed class QueueService : ServiceBase, IQueueService
         // while all messages are not sent to the Service Bus queue
         while (messages.Count > 0)
         {
-            using var messageBatch = await sender.CreateMessageBatchAsync(cancellationToken);
+            using var messageBatch = await sender.CreateMessageBatchAsync(cancellationToken).ConfigureAwait(false);
             // add the first message to the batch
             if (messageBatch.TryAddMessage(messages.Peek()))
             {
@@ -73,7 +73,7 @@ public sealed class QueueService : ServiceBase, IQueueService
             }
 
             // now, send the batch
-            await sender.SendMessagesAsync(messageBatch, cancellationToken);
+            await sender.SendMessagesAsync(messageBatch, cancellationToken).ConfigureAwait(false);
 
             // if there are any remaining messages in the .NET queue, the while loop repeats
         }
@@ -96,11 +96,11 @@ public sealed class QueueService : ServiceBase, IQueueService
         processor.ProcessErrorAsync += ErrorHandler;
 
         // start processing
-        await processor.StartProcessingAsync(cancellationToken);
+        await processor.StartProcessingAsync(cancellationToken).ConfigureAwait(false);
 
         // stop processing
         _logger.LogInformation("{ClassName} Stopping the receiver...", nameof(QueueService));
-        await processor.StopProcessingAsync(cancellationToken);
+        await processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("{ClassName} Stopped receiving messages", nameof(QueueService));
     }
 }

--- a/src/CasCap.Api.Azure.ServiceBus/Services/QueueService.cs
+++ b/src/CasCap.Api.Azure.ServiceBus/Services/QueueService.cs
@@ -1,7 +1,7 @@
 namespace CasCap.Services;
 
 /// <inheritdoc/>
-public class QueueService : ServiceBase, IQueueService
+public sealed class QueueService : ServiceBase, IQueueService
 {
     private readonly string _queueName;
 

--- a/src/CasCap.Api.Azure.ServiceBus/Services/TopicService.cs
+++ b/src/CasCap.Api.Azure.ServiceBus/Services/TopicService.cs
@@ -1,7 +1,7 @@
 namespace CasCap.Services;
 
 /// <inheritdoc/>
-public class TopicService : ServiceBase, ITopicService
+public sealed class TopicService : ServiceBase, ITopicService
 {
     private readonly string _topicName;
     private readonly string _subscriptionName;

--- a/src/CasCap.Api.Azure.ServiceBus/Services/TopicService.cs
+++ b/src/CasCap.Api.Azure.ServiceBus/Services/TopicService.cs
@@ -37,7 +37,7 @@ public sealed class TopicService : ServiceBase, ITopicService
         await using var client = _client;
         // create a sender for the topic
         var sender = client.CreateSender(_topicName);
-        await sender.SendMessageAsync(message, cancellationToken);
+        await sender.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("{ClassName} Sent a single message to the topic: {TopicName}",
             nameof(TopicService), _topicName);
     }
@@ -56,7 +56,7 @@ public sealed class TopicService : ServiceBase, ITopicService
         while (messages.Count > 0)
         {
             // start a new batch
-            using var messageBatch = await sender.CreateMessageBatchAsync(cancellationToken);
+            using var messageBatch = await sender.CreateMessageBatchAsync(cancellationToken).ConfigureAwait(false);
             // add the first message to the batch
             if (messageBatch.TryAddMessage(messages.Peek()))
             {
@@ -77,7 +77,7 @@ public sealed class TopicService : ServiceBase, ITopicService
             }
 
             // now, send the batch
-            await sender.SendMessagesAsync(messageBatch, cancellationToken);
+            await sender.SendMessagesAsync(messageBatch, cancellationToken).ConfigureAwait(false);
 
             // if there are any remaining messages in the .NET queue, the while loop repeats
         }
@@ -100,11 +100,11 @@ public sealed class TopicService : ServiceBase, ITopicService
         processor.ProcessErrorAsync += ErrorHandler;
 
         // start processing
-        await processor.StartProcessingAsync(cancellationToken);
+        await processor.StartProcessingAsync(cancellationToken).ConfigureAwait(false);
 
         // stop processing
         _logger.LogInformation("{ClassName} Stopping the receiver...", nameof(TopicService));
-        await processor.StopProcessingAsync(cancellationToken);
+        await processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
         _logger.LogInformation("{ClassName} Stopped receiving messages", nameof(TopicService));
     }
 }

--- a/src/CasCap.Api.Azure.Storage/Extensions/StorageExtensions.cs
+++ b/src/CasCap.Api.Azure.Storage/Extensions/StorageExtensions.cs
@@ -1,7 +1,7 @@
 namespace CasCap.Common.Extensions;
 
 /// <summary>Extension methods for Azure Table Storage key and date helpers.</summary>
-public static class StorageExtensions
+public static partial class StorageExtensions
 {
     /// <summary>
     /// Checks whether a table with the specified name exists in the given <see cref="TableServiceClient"/>.
@@ -11,12 +11,13 @@ public static class StorageExtensions
     /// <returns><see langword="true"/> if the table exists; otherwise, <see langword="false"/>.</returns>
     public static async Task<bool> ExistsAsync(this TableServiceClient client, string tableName)
     {
-        await foreach (var tbl in client.QueryAsync(t => t.Name == tableName))
+        await foreach (var tbl in client.QueryAsync(t => t.Name == tableName).ConfigureAwait(false))
             return true;
         return false;
     }
 
-    private static readonly Regex DisallowedCharsInTableKeys = new(@"[\\\\#%/?\^\u0000-\u001F\u007F-\u009F]", RegexOptions.Compiled);
+    [GeneratedRegex(@"[\\\\#%/?\^\u0000-\u001F\u007F-\u009F]")]
+    private static partial Regex DisallowedCharsInTableKeysRegex();
     //private static readonly Regex DisallowedCharsInTableKeys = new("[#]", RegexOptions.Compiled);
     //https://stackoverflow.com/questions/11514707/azure-table-storage-rowkey-restricted-character-patterns
     /// <summary>
@@ -27,7 +28,7 @@ public static class StorageExtensions
     /// <seealso href="https://stackoverflow.com/questions/11514707/azure-table-storage-rowkey-restricted-character-patterns"/>
     public static bool IsKeyValid(this string tableKey)
     {
-        return !DisallowedCharsInTableKeys.IsMatch(tableKey);
+        return !DisallowedCharsInTableKeysRegex().IsMatch(tableKey);
         //string sanitizedKey = DisallowedCharsInTableKeys.Replace(tableKey, disallowedCharReplacement);
     }
 
@@ -41,7 +42,7 @@ public static class StorageExtensions
     public static DateTime GetDateFromFileName(this string path, DateTimeKind kind = DateTimeKind.Utc)
     {
         var fileName = Path.GetFileNameWithoutExtension(path);
-        var strDt = fileName.Substring(0, 10);
+        var strDt = fileName.AsSpan(0, 10);
         if (DateTime.TryParse(strDt, out var date))
             return DateTime.SpecifyKind(date, kind);
         else

--- a/src/CasCap.Api.Azure.Storage/Messages/AzTableStorageArgs.cs
+++ b/src/CasCap.Api.Azure.Storage/Messages/AzTableStorageArgs.cs
@@ -5,7 +5,7 @@ namespace CasCap.Messages;
 /// describing the batch that was just processed.
 /// </summary>
 /// <remarks>Some properties use camelCase naming to preserve backward compatibility with existing consumers.</remarks>
-public class AzTableStorageArgs(string storageAccountName, string tableName, string partitionKey, int count, int countRemaining, DateTime time)
+public sealed class AzTableStorageArgs(string storageAccountName, string tableName, string partitionKey, int count, int countRemaining, DateTime time)
 {
 
     /// <summary>Gets or sets the name of the storage account that owns the table.</summary>

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzBlobStorageBase.cs
@@ -40,25 +40,25 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     /// <inheritdoc/>
     public async Task<bool> CreateContainerIfNotExists(CancellationToken cancellationToken)
     {
-        var response = await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        var response = await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         return response is not null;
     }
 
     /// <inheritdoc/>
     public async Task DeleteBlob(string blobName, CancellationToken cancellationToken)
-        => _ = await _containerClient.DeleteBlobIfExistsAsync(blobName, cancellationToken: cancellationToken);
+        => _ = await _containerClient.DeleteBlobIfExistsAsync(blobName, cancellationToken: cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc/>
     public async Task<byte[]?> DownloadBlobAsync(string blobName, CancellationToken cancellationToken = default)
     {
         var blobClient = _containerClient.GetBlobClient(blobName);
 
-        if (!await blobClient.ExistsAsync(cancellationToken))
+        if (!await blobClient.ExistsAsync(cancellationToken).ConfigureAwait(false))
         {
             _logger.LogWarning("{ClassName} blob {BlobName} does not exist", nameof(AzBlobStorageBase), blobName);
             return null;
         }
-        var response = await blobClient.DownloadContentAsync(cancellationToken);
+        var response = await blobClient.DownloadContentAsync(cancellationToken).ConfigureAwait(false);
         return response.Value.Content.ToArray();
     }
 
@@ -66,7 +66,7 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     public async Task<List<BlobItem>> ListContainerBlobs(string? prefix = null, CancellationToken cancellationToken = default)
     {
         var blobs = new List<BlobItem>();
-        await foreach (var blobItem in _containerClient.GetBlobsAsync(new GetBlobsOptions { Prefix = prefix }, cancellationToken: cancellationToken))
+        await foreach (var blobItem in _containerClient.GetBlobsAsync(new GetBlobsOptions { Prefix = prefix }, cancellationToken: cancellationToken).ConfigureAwait(false))
             blobs.Add(blobItem);
         return blobs;
     }
@@ -75,7 +75,7 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     public async Task<List<string>> GetBlobPrefixes(string? prefix = null, CancellationToken cancellationToken = default)
     {
         var hs = new HashSet<string>();
-        await foreach (var hierarchyItem in _containerClient.GetBlobsByHierarchyAsync(new GetBlobsByHierarchyOptions { Prefix = prefix, Delimiter = "/" }, cancellationToken: cancellationToken))
+        await foreach (var hierarchyItem in _containerClient.GetBlobsByHierarchyAsync(new GetBlobsByHierarchyOptions { Prefix = prefix, Delimiter = "/" }, cancellationToken: cancellationToken).ConfigureAwait(false))
             hs.Add(hierarchyItem.Prefix);
         var prefixes = hs.Select(p => p.Replace("/", string.Empty)).ToList();
         _logger.LogDebug("{ClassName} prefixes returned from blob storage are; {Prefixes}",
@@ -88,13 +88,13 @@ public abstract class AzBlobStorageBase : IAzBlobStorageBase
     {
         var blobClient = _containerClient.GetBlobClient(blobName);
         using var stream = new MemoryStream(bytes, writable: false);
-        _ = await blobClient.UploadAsync(stream, true, cancellationToken);
+        _ = await blobClient.UploadAsync(stream, true, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task UploadBlob(string blobName, Stream stream, CancellationToken cancellationToken)
     {
         var blobClient = _containerClient.GetBlobClient(blobName);
-        _ = await blobClient.UploadAsync(stream, true, cancellationToken);
+        _ = await blobClient.UploadAsync(stream, true, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzQueueStorageBase.cs
@@ -40,7 +40,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     {
         if (Interlocked.CompareExchange(ref _queueExistsChecked, 1, 0) == 0)
         {
-            if (await _queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken) is not null)
+            if (await _queueClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false) is not null)
                 _logger.LogDebug("{ClassName} storage queue didn't exist so have now created {QueueName}", nameof(AzQueueStorageBase), _queueClient.Name);
         }
     }
@@ -51,7 +51,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     /// <inheritdoc/>
     public async Task<bool> Enqueue<T>(List<T> objs, CancellationToken cancellationToken = default) where T : class
     {
-        await CreateQueueIfNotExistsAsync(cancellationToken);
+        await CreateQueueIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
         var successCount = 0;
         foreach (var obj in objs)
         {
@@ -65,7 +65,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             Azure.Response<SendReceipt>? result = null;
             try
             {
-                result = await _queueClient.SendMessageAsync(message, default, default, cancellationToken);
+                result = await _queueClient.SendMessageAsync(message, default, default, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -85,8 +85,8 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     /// <inheritdoc/>
     public async Task<(T?, QueueMessage)> DequeueSingle<T>(CancellationToken cancellationToken = default) where T : class
     {
-        await CreateQueueIfNotExistsAsync(cancellationToken);
-        var retrievedMessage = await _queueClient.ReceiveMessageAsync(cancellationToken: cancellationToken);
+        await CreateQueueIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
+        var retrievedMessage = await _queueClient.ReceiveMessageAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         if (retrievedMessage is not null && retrievedMessage.Value is not null)
         {
             var json = retrievedMessage.Value.Body.ToString();
@@ -103,7 +103,7 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             }
             finally
             {
-                _ = await _queueClient.DeleteMessageAsync(retrievedMessage.Value.MessageId, retrievedMessage.Value.PopReceipt, cancellationToken);
+                _ = await _queueClient.DeleteMessageAsync(retrievedMessage.Value.MessageId, retrievedMessage.Value.PopReceipt, cancellationToken).ConfigureAwait(false);
                 if (isCorrupted)
                     _logger.LogWarning("{ClassName} removed corrupted message {MessageId} from queue {QueueName}",
                         nameof(AzQueueStorageBase), retrievedMessage.Value.MessageId, _queueClient.Name);
@@ -120,8 +120,8 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
     /// <inheritdoc/>
     public async Task<List<T>> DequeueMany<T>(int limit = 1, CancellationToken cancellationToken = default) where T : class
     {
-        await CreateQueueIfNotExistsAsync(cancellationToken);
-        var messages = await Dequeue(limit, cancellationToken);
+        await CreateQueueIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
+        var messages = await Dequeue(limit, cancellationToken).ConfigureAwait(false);
         var l = new List<T>(messages.Count);
         foreach (var retrievedMessage in messages)
         {
@@ -129,19 +129,19 @@ public abstract class AzQueueStorageBase : IAzQueueStorageBase
             var obj = json.FromJson<T>();
             l.Add(obj!);
             //delete each message after processing
-            await _queueClient.DeleteMessageAsync(retrievedMessage.MessageId, retrievedMessage.PopReceipt, cancellationToken);
+            await _queueClient.DeleteMessageAsync(retrievedMessage.MessageId, retrievedMessage.PopReceipt, cancellationToken).ConfigureAwait(false);
         }
         return l;
     }
 
     private async Task<List<QueueMessage>> Dequeue(int limit = 1, CancellationToken cancellationToken = default)
     {
-        var properties = await _queueClient.GetPropertiesAsync(cancellationToken);
+        var properties = await _queueClient.GetPropertiesAsync(cancellationToken).ConfigureAwait(false);
         var available = properties.Value.ApproximateMessagesCount;
         var maxMessages = Math.Min(limit, Math.Min(available, 32));
         if (maxMessages <= 0)
             return [];
-        var messages = await _queueClient.ReceiveMessagesAsync(maxMessages, cancellationToken: cancellationToken);
+        var messages = await _queueClient.ReceiveMessagesAsync(maxMessages, cancellationToken: cancellationToken).ConfigureAwait(false);
         return [.. messages.Value];
     }
 }

--- a/src/CasCap.Api.Azure.Storage/Services/Base/AzTableStorageBase.cs
+++ b/src/CasCap.Api.Azure.Storage/Services/Base/AzTableStorageBase.cs
@@ -43,8 +43,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     public async Task<TableClient> GetTableClient(string tableName, bool CreateIfNotExists = true, CancellationToken cancellationToken = default)
     {
         var table = _tableSvcClient.GetTableClient(tableName);
-        if (!await _tableSvcClient.ExistsAsync(tableName) && CreateIfNotExists)
-            await table.CreateIfNotExistsAsync(cancellationToken);
+        if (!await _tableSvcClient.ExistsAsync(tableName).ConfigureAwait(false) && CreateIfNotExists)
+            await table.CreateIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
         return table;
     }
 
@@ -53,8 +53,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
         var table = _tableSvcClient.GetTableClient(tableName);
-        if (!await _tableSvcClient.ExistsAsync(table.Name) && CreateIfNotExists)
-            await table.CreateIfNotExistsAsync(cancellationToken);
+        if (!await _tableSvcClient.ExistsAsync(table.Name).ConfigureAwait(false) && CreateIfNotExists)
+            await table.CreateIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
         return table;
     }
 
@@ -62,22 +62,22 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task<int> UpsertEntity<T>(string tableName, T entity, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var table = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await UpsertEntity<T>(table, entity, cancellationToken);
+        var table = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await UpsertEntity<T>(table, entity, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task<int> UpsertEntity<T>(TableClient tbl, T entity, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var result = await tbl.UpsertEntityAsync(entity, cancellationToken: cancellationToken);
+        var result = await tbl.UpsertEntityAsync(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         return result.Status;
     }
 
     /// <inheritdoc/>
     public async Task<List<T>> UploadData<T>(string tableName, List<T> entities, bool useParallelism = true, CancellationToken cancellationToken = default) where T : class, ITableEntity
     {
-        var tbl = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await BatchOperation(tbl, entities, useParallelism, cancellationToken: cancellationToken);
+        var tbl = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await BatchOperation(tbl, entities, useParallelism, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -98,8 +98,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
         var po = new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = useParallelism ? Environment.ProcessorCount : 1 };
         await Parallel.ForEachAsync(partitions, po, async (p, ct) =>
         {
-            await RunBatches(p.PartitionKey, p.Entities, ct);
-        });
+            await RunBatches(p.PartitionKey, p.Entities, ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
 
         return retval.ToList();
 
@@ -110,7 +110,7 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
                 var count = partitionEntities.Count;
                 var batchSize = Math.Min(100, count);
                 var batch = partitionEntities.Take(batchSize).ToList();
-                var batchResult = await ExecuteBatchOperation(batch, cancellationToken);
+                var batchResult = await ExecuteBatchOperation(batch, cancellationToken).ConfigureAwait(false);
                 if (batchResult.Count > 0)
                 {
                     partitionEntities.RemoveRange(0, batchSize);
@@ -140,7 +140,7 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
                 var newTableTxnRows = new List<TableTransactionAction>();
                 foreach (var ent in tableTxnRows)
                 {
-                    var exists = await tbl.GetEntityIfExistsAsync<T>(ent.Entity.PartitionKey, ent.Entity.RowKey, cancellationToken: cancellationToken);
+                    var exists = await tbl.GetEntityIfExistsAsync<T>(ent.Entity.PartitionKey, ent.Entity.RowKey, cancellationToken: cancellationToken).ConfigureAwait(false);
                     if (exists.HasValue)
                         newTableTxnRows.Add(ent);
                 }
@@ -172,8 +172,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task<T?> GetEntity<T>(string tableName, string partitionKey, string? rowKey = null, CancellationToken cancellationToken = default) where T : class, ITableEntity, new()
     {
-        var table = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await GetEntity<T>(table, partitionKey, rowKey, cancellationToken);
+        var table = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await GetEntity<T>(table, partitionKey, rowKey, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -181,7 +181,7 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     {
         if (string.IsNullOrWhiteSpace(rowKey))
             throw new NotImplementedException("TODO: need to create an ODATA query for TOP 1 operations...");
-        var result = await tbl.GetEntityIfExistsAsync<T>(partitionKey, rowKey, cancellationToken: cancellationToken);
+        var result = await tbl.GetEntityIfExistsAsync<T>(partitionKey, rowKey, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (result.HasValue)
             return result.Value;
         return null;
@@ -190,8 +190,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task<List<T>> GetEntities<T>(string tableName, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var table = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await GetEntities<T>(table, cancellationToken);
+        var table = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await GetEntities<T>(table, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -201,8 +201,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task<List<T>> GetEntities<T>(string tableName, string partitionKey, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var table = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await GetEntities<T>(table, partitionKey, cancellationToken);
+        var table = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await GetEntities<T>(table, partitionKey, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -213,8 +213,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task<List<T>> GetEntities<T>(string tableName, string partitionKey, string rowKeyFrom, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var table = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await GetEntities<T>(table, partitionKey, rowKeyFrom, cancellationToken);
+        var table = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await GetEntities<T>(table, partitionKey, rowKeyFrom, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -227,8 +227,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task<List<T>> GetEntities<T>(string tableName, string partitionKey, string rowKeyFrom, string rowKeyTo, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var tbl = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        return await GetEntities<T>(tbl, partitionKey, rowKeyFrom, rowKeyTo, cancellationToken);
+        var tbl = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return await GetEntities<T>(tbl, partitionKey, rowKeyFrom, rowKeyTo, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -247,9 +247,9 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <summary>Deletes the specified table if it exists.</summary>
     public async Task DeleteTable(string tableName, CancellationToken cancellationToken)
     {
-        if (await _tableSvcClient.ExistsAsync(tableName))
+        if (await _tableSvcClient.ExistsAsync(tableName).ConfigureAwait(false))
         {
-            var response = await _tableSvcClient.DeleteTableAsync(tableName, cancellationToken);
+            var response = await _tableSvcClient.DeleteTableAsync(tableName, cancellationToken).ConfigureAwait(false);
             _logger.LogDebug("{ClassName} {TableName} {ReasonPhrase}", nameof(AzTableStorageBase), tableName, response.ReasonPhrase);
         }
     }
@@ -257,8 +257,8 @@ public abstract class AzTableStorageBase : IAzTableStorageBase
     /// <inheritdoc/>
     public async Task DeleteData<T>(string tableName, List<T> entities, CancellationToken cancellationToken) where T : class, ITableEntity, new()
     {
-        var tbl = await GetTableClient(tableName, cancellationToken: cancellationToken);
-        await BatchOperation(tbl, entities, useParallelism: true, InsertOrReplace: false, cancellationToken: cancellationToken);
+        var tbl = await GetTableClient(tableName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await BatchOperation(tbl, entities, useParallelism: true, InsertOrReplace: false, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary

Systematic performance optimizations applied across all library projects, following the conventions in `copilot-instructions.md`.

## Changes

### Performance Optimizations

1. **sealed classes** — Mark 5 concrete classes `sealed` for JIT devirtualization:
   - `SpeechService`, `QueryService`, `QueueService`, `TopicService`, `AzTableStorageArgs`

2. **ConfigureAwait(false)** — Add `.ConfigureAwait(false)` to ~60 `await` calls across 11 library files. These are library projects (not application entry points) so must avoid capturing `SynchronizationContext`.

3. **GeneratedRegex** — Convert `DisallowedCharsInTableKeys` from `new Regex(..., RegexOptions.Compiled)` to source-generated `[GeneratedRegex]`, eliminating runtime regex compilation and reducing startup cost.

4. **Span-based parsing** — Replace `fileName.Substring(0, 10)` with `fileName.AsSpan(0, 10)` in `GetDateFromFileName`, avoiding an intermediate string allocation.

### Other

- Update `copilot-instructions.md` with expanded Performance section (ValueTask, sealed, Frozen Collections, ConfigureAwait, SearchValues, System.Threading.Lock, Hot-Path conventions)
- Bump `CasCap.Common.*` packages from 4.11.6 → 4.11.7
- Bump `Microsoft.NET.Test.Sdk` from 18.5.1 → 18.6.0