### PR TITLE
Bump Azure SDK, CasCap.Common and Microsoft.Extensions packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Core" Version="1.57.0" />
+    <PackageVersion Include="Azure.Core" Version="1.58.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />
@@ -12,8 +12,8 @@
     <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
     <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.8" />
     <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.8" />
     <PackageVersion Include="CasCap.Common.Logging" Version="4.11.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Core" Version="1.58.0" />
+    <PackageVersion Include="Azure.Core" Version="1.59.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="5.0.0" />
@@ -14,14 +14,14 @@
     <PackageVersion Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
-    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.8" />
-    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.8" />
-    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.8" />
-    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.8" />
-    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.8" />
-    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.8" />
+    <PackageVersion Include="CasCap.Common.Abstractions" Version="4.11.9" />
+    <PackageVersion Include="CasCap.Common.Extensions" Version="4.11.9" />
+    <PackageVersion Include="CasCap.Common.Logging" Version="4.11.9" />
+    <PackageVersion Include="CasCap.Common.Serialization.Json" Version="4.11.9" />
+    <PackageVersion Include="CasCap.Common.Serialization.MessagePack" Version="4.11.9" />
+    <PackageVersion Include="CasCap.Common.Testing" Version="4.11.9" />
     <PackageVersion Include="Microsoft.CognitiveServices.Speech" Version="1.50.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />


### PR DESCRIPTION
## Summary

Dependency version updates across Azure SDK, internal CasCap.Common packages, and Microsoft.Extensions.

## Package Updates

| Package | From | To |
| --- | --- | --- |
| `Azure.Core` | 1.57.0 | 1.59.0 |
| `Azure.Storage.Blobs` | 12.28.0 | 12.29.0 |
| `Azure.Storage.Queues` | 12.26.0 | 12.27.0 |
| `CasCap.Common.Abstractions` | 4.11.8 | 4.11.9 |
| `CasCap.Common.Extensions` | 4.11.8 | 4.11.9 |
| `CasCap.Common.Logging` | 4.11.8 | 4.11.9 |
| `CasCap.Common.Serialization.Json` | 4.11.8 | 4.11.9 |
| `CasCap.Common.Serialization.MessagePack` | 4.11.8 | 4.11.9 |
| `CasCap.Common.Testing` | 4.11.8 | 4.11.9 |
| `Microsoft.Extensions.Configuration.Json` | 10.0.8 | 10.0.9 |

## Changes

- Updated `Directory.Packages.props` only — no code changes.